### PR TITLE
Add grading system and term CRUD use cases

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -13,78 +13,54 @@ import { SubjectListContainer } from "./scolar/presentation/ui/Subject/List/Subj
 import { SubjectCreateContainer } from "./scolar/presentation/ui/Subject/Create/SubjectCreateContainer";
 import { SubjectCourseContainer } from "./scolar/presentation/ui/Course/SubjectCourse/SubjectCourseContainer";
 import { EditCourseContainer } from "./scolar/presentation/ui/Course/Edit/CourseEditContainer";
+import { EvaluationTypeListContainer } from "./scolar/presentation/ui/EvaluationType/List/EvaluationTypeListContainer";
+import { EvaluationTypeCreateContainer } from "./scolar/presentation/ui/EvaluationType/Create/EvaluationTypeCreateContainer";
+import { EvaluationTypeEditContainer } from "./scolar/presentation/ui/EvaluationType/Edit/EvaluationTypeEditContainer";
+import { GradingSystemListContainer } from "./scolar/presentation/ui/GradingSystem/List/GradingSystemListContainer";
+import { GradingSystemCreateContainer } from "./scolar/presentation/ui/GradingSystem/Create/GradingSystemCreateContainer";
+import { GradingSystemEditContainer } from "./scolar/presentation/ui/GradingSystem/Edit/GradingSystemEditContainer";
+import { GradingTermListContainer } from "./scolar/presentation/ui/GradingTerm/List/GradingTermListContainer";
+import { GradingTermCreateContainer } from "./scolar/presentation/ui/GradingTerm/Create/GradingTermCreateContainer";
+import { GradingTermEditContainer } from "./scolar/presentation/ui/GradingTerm/Edit/GradingTermEditContainer";
 
 const isStandalone = !window.singleSpaNavigate;
 
-export const  MenuOptions = [
+export const MenuOptions = [
     { name: 'Cursos', path: '/cursos' },
-    {name:'Niveles Escolares', path:'/niveles-escolares' },
-    {name:'Paralelos', path:'/paralelos' },
-    {name:'Materias', path:'/materias' },
-    {name:'Periodos lectivos', path:'/periodos-lectivos' }
-]
-
+    { name: 'Niveles Escolares', path: '/niveles-escolares' },
+    { name: 'Paralelos', path: '/paralelos' },
+    { name: 'Materias', path: '/materias' },
+    { name: 'Periodos lectivos', path: '/periodos-lectivos' },
+    { name: 'Sistemas de calificación', path: '/sistemas-calificacion' },
+    { name: 'Períodos de calificación', path: '/terminos-calificacion' },
+    { name: 'Tipos de evaluación', path: '/tipos-evaluacion' }
+];
 
 const router = createBrowserRouter([
-    {
-        path: "/cursos",
-        Component: CourseListContainer
-    },
-    {
-        path: "/cursos/nuevo",
-        Component: CreateCourseContainer
-    },
-    {
-        path: "/cursos/:id",
-        Component: EditCourseContainer,
-    },
-    {
-        path: "/niveles-escolares",
-        Component: LevelListContainer
-    },
-    {
-        path: "/niveles-escolares/nuevo",
-        Component: LevelCreateContainer
-    },
-    {
-        path:"/niveles-escolares/:id",
-        Component: EditLevelContainer
-    },
-    {
-        path: "/paralelos",
-        Component: ListParallelContainer
-    },
-    {
-        path:"/cursos/:courseId/paralelos",
-        Component: ListByCourseContainer
-    },
-    {
-        path:"/periodos-lectivos",
-        Component: ListSchoolYearContainer
-    },
-    {
-        path:"/periodos-lectivos/nuevo",
-        Component: CreateSchoolYearContainer
-    },
-    {
-        path:"/periodos-lectivos/:id",
-        Component: EditSchoolYearContainer
-    },
-    {
-        path:"/materias",
-        Component: SubjectListContainer
-    },
-    {
-        path:"/materias/nuevo",
-        Component: SubjectCreateContainer
-    },
-    {
-        path:"/cursos/:id/materias",
-        Component: SubjectCourseContainer
-    }
-
-],
-{
+    { path: '/cursos', Component: CourseListContainer },
+    { path: '/cursos/nuevo', Component: CreateCourseContainer },
+    { path: '/cursos/:id', Component: EditCourseContainer },
+    { path: '/niveles-escolares', Component: LevelListContainer },
+    { path: '/niveles-escolares/nuevo', Component: LevelCreateContainer },
+    { path: '/niveles-escolares/:id', Component: EditLevelContainer },
+    { path: '/paralelos', Component: ListParallelContainer },
+    { path: '/cursos/:courseId/paralelos', Component: ListByCourseContainer },
+    { path: '/periodos-lectivos', Component: ListSchoolYearContainer },
+    { path: '/periodos-lectivos/nuevo', Component: CreateSchoolYearContainer },
+    { path: '/periodos-lectivos/:id', Component: EditSchoolYearContainer },
+    { path: '/materias', Component: SubjectListContainer },
+    { path: '/materias/nuevo', Component: SubjectCreateContainer },
+    { path: '/cursos/:id/materias', Component: SubjectCourseContainer },
+    { path: '/tipos-evaluacion', Component: EvaluationTypeListContainer },
+    { path: '/tipos-evaluacion/nuevo', Component: EvaluationTypeCreateContainer },
+    { path: '/tipos-evaluacion/:id', Component: EvaluationTypeEditContainer },
+    { path: '/sistemas-calificacion', Component: GradingSystemListContainer },
+    { path: '/sistemas-calificacion/nuevo', Component: GradingSystemCreateContainer },
+    { path: '/sistemas-calificacion/:id', Component: GradingSystemEditContainer },
+    { path: '/terminos-calificacion', Component: GradingTermListContainer },
+    { path: '/terminos-calificacion/nuevo', Component: GradingTermCreateContainer },
+    { path: '/terminos-calificacion/:id', Component: GradingTermEditContainer },
+], {
     basename: isStandalone ? '/' : '/escolar',
 });
 

--- a/src/scolar/application/useCases/evaluationTypes/createEvaluationTypeUseCase.ts
+++ b/src/scolar/application/useCases/evaluationTypes/createEvaluationTypeUseCase.ts
@@ -1,0 +1,55 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import { EvaluationType } from "@/scolar/domain/entities/evaluation_type";
+import { Either, Left, Right } from "purify-ts/Either";
+import { EVALUATION_TYPE_SERVICE } from "@/scolar/domain/symbols/EvaluationTypeSymbol";
+import { EvaluationTypeService } from "@/scolar/domain/services/EvaluationTypeService";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { EvaluationTypeError } from "@/scolar/domain/entities/EvaluationTypeError";
+import { inject, injectable } from "inversify";
+import Failure from "@/scolar/domain/failure";
+import { isAxiosError } from "axios";
+
+export class CreateEvaluationTypeCommand implements UseCaseCommand {
+    constructor(
+        private name: string,
+        private description: string,
+        private weight: string
+    ) {}
+
+    get data() {
+        return new EvaluationType(
+            0,
+            this.name,
+            this.description,
+            this.weight
+        );
+    }
+}
+
+export type CreateEvaluationTypeUseCase = UseCase<EvaluationType, CreateEvaluationTypeCommand>;
+
+@injectable()
+export class CreateEvaluationTypeUseCaseImpl implements CreateEvaluationTypeUseCase {
+    constructor(
+        @inject(EVALUATION_TYPE_SERVICE) private evaluationTypeService: EvaluationTypeService,
+        @inject(LOGGER) private logger: Logger
+    ) {}
+
+    async execute(command: CreateEvaluationTypeCommand): Promise<Either<Failure[], EvaluationType | undefined>> {
+        try {
+            const res = await this.evaluationTypeService.create(command.data);
+            return Right(res);
+        } catch (e) {
+            if (isAxiosError(e)) {
+                this.logger.error(JSON.stringify(e.response?.data));
+                const message = e.response?.data?.message;
+                const error = e.response?.data?.error;
+                if (message && error) {
+                    return Left([new EvaluationTypeError(error, message, error)]);
+                }
+            }
+            return Left([EvaluationTypeError.EVALUATION_TYPE_SERVICE_ERROR]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/evaluationTypes/deleteEvaluationTypeUseCase.ts
+++ b/src/scolar/application/useCases/evaluationTypes/deleteEvaluationTypeUseCase.ts
@@ -1,0 +1,36 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import { Either, Left, Right } from "purify-ts/Either";
+import { EVALUATION_TYPE_SERVICE } from "@/scolar/domain/symbols/EvaluationTypeSymbol";
+import { EvaluationTypeService } from "@/scolar/domain/services/EvaluationTypeService";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+import { EvaluationTypeError } from "@/scolar/domain/entities/EvaluationTypeError";
+import { inject, injectable } from "inversify";
+
+export class DeleteEvaluationTypeCommand implements UseCaseCommand {
+    constructor(private id: number) {}
+
+    get data() {
+        return this.id;
+    }
+}
+
+export type DeleteEvaluationTypeUseCase = UseCase<void, DeleteEvaluationTypeCommand>;
+
+@injectable()
+export class DeleteEvaluationTypeUseCaseImpl implements DeleteEvaluationTypeUseCase {
+    constructor(
+        @inject(EVALUATION_TYPE_SERVICE) private evaluationTypeService: EvaluationTypeService,
+        @inject(LOGGER) private logger: Logger
+    ) {}
+
+    async execute(command: DeleteEvaluationTypeCommand): Promise<Either<EvaluationTypeError[], void>> {
+        try {
+            const res = await this.evaluationTypeService.delete(command.data);
+            return Right(res);
+        } catch (e) {
+            this.logger.error(JSON.stringify(e));
+            return Left([EvaluationTypeError.EVALUATION_TYPE_SERVICE_ERROR]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/evaluationTypes/getEvaluationTypeUseCase.ts
+++ b/src/scolar/application/useCases/evaluationTypes/getEvaluationTypeUseCase.ts
@@ -1,0 +1,37 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import { EvaluationType } from "@/scolar/domain/entities/evaluation_type";
+import { EVALUATION_TYPE_SERVICE } from "@/scolar/domain/symbols/EvaluationTypeSymbol";
+import { EvaluationTypeService } from "@/scolar/domain/services/EvaluationTypeService";
+import { EvaluationTypeError } from "@/scolar/domain/entities/EvaluationTypeError";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+import { inject, injectable } from "inversify";
+import { Either, Left, Right } from "purify-ts/Either";
+
+export class GetEvaluationTypeCommand implements UseCaseCommand {
+    constructor(private id: number) {}
+
+    get data() {
+        return this.id;
+    }
+}
+
+export type GetEvaluationTypeUseCase = UseCase<EvaluationType, GetEvaluationTypeCommand>;
+
+@injectable()
+export class GetEvaluationTypeUseCaseImpl implements GetEvaluationTypeUseCase {
+    constructor(
+        @inject(EVALUATION_TYPE_SERVICE) private evaluationTypeService: EvaluationTypeService,
+        @inject(LOGGER) private logger: Logger
+    ) {}
+
+    async execute(command: GetEvaluationTypeCommand): Promise<Either<EvaluationTypeError[], EvaluationType | undefined>> {
+        try {
+            const result = await this.evaluationTypeService.get(command.data);
+            return Right(result);
+        } catch (e) {
+            this.logger.error(JSON.stringify(e));
+            return Left([EvaluationTypeError.EVALUATION_TYPE_SERVICE_ERROR]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/evaluationTypes/listEvaluationTypeUseCase.ts
+++ b/src/scolar/application/useCases/evaluationTypes/listEvaluationTypeUseCase.ts
@@ -1,0 +1,35 @@
+import { PaginateUseCaseCommand, UseCase } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { EvaluationType } from "@/scolar/domain/entities/evaluation_type";
+import { EVALUATION_TYPE_SERVICE } from "@/scolar/domain/symbols/EvaluationTypeSymbol";
+import { EvaluationTypeService } from "@/scolar/domain/services/EvaluationTypeService";
+import { extractErrorMessage } from "@/lib/utils";
+import { inject, injectable } from "inversify";
+import { Either, Left, Right } from "purify-ts/Either";
+
+export class ListEvaluationTypeCommand extends PaginateUseCaseCommand {}
+
+export type ListEvaluationTypeUseCase = UseCase<PaginatedResult<EvaluationType>, ListEvaluationTypeCommand>;
+
+@injectable()
+export class ListEvaluationTypeUseCaseImpl implements ListEvaluationTypeUseCase {
+    constructor(
+        @inject(EVALUATION_TYPE_SERVICE) private evaluationTypeService: EvaluationTypeService
+    ) {}
+
+    async execute(command: ListEvaluationTypeCommand): Promise<Either<Failure[], PaginatedResult<EvaluationType> | undefined>> {
+        try {
+            const result = await this.evaluationTypeService.all(
+                command.data.page,
+                command.data.perPage,
+                command.data.search,
+                command.data.orderBy
+            );
+            return Right(result);
+        } catch (error) {
+            const _error = extractErrorMessage(error);
+            return Left([_error]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/evaluationTypes/updateEvaluationTypeUseCase.ts
+++ b/src/scolar/application/useCases/evaluationTypes/updateEvaluationTypeUseCase.ts
@@ -1,0 +1,55 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import { EvaluationType } from "@/scolar/domain/entities/evaluation_type";
+import { Either, Left, Right } from "purify-ts/Either";
+import { EVALUATION_TYPE_SERVICE } from "@/scolar/domain/symbols/EvaluationTypeSymbol";
+import { EvaluationTypeService } from "@/scolar/domain/services/EvaluationTypeService";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+import { EvaluationTypeError } from "@/scolar/domain/entities/EvaluationTypeError";
+import { inject, injectable } from "inversify";
+import { isAxiosError } from "axios";
+
+export class UpdateEvaluationTypeCommand implements UseCaseCommand {
+    constructor(
+        private id: number,
+        private name: string,
+        private description: string,
+        private weight: string
+    ) {}
+
+    get data() {
+        return new EvaluationType(
+            this.id,
+            this.name,
+            this.description,
+            this.weight
+        );
+    }
+}
+
+export type UpdateEvaluationTypeUseCase = UseCase<EvaluationType, UpdateEvaluationTypeCommand>;
+
+@injectable()
+export class UpdateEvaluationTypeUseCaseImpl implements UpdateEvaluationTypeUseCase {
+    constructor(
+        @inject(EVALUATION_TYPE_SERVICE) private evaluationTypeService: EvaluationTypeService,
+        @inject(LOGGER) private logger: Logger
+    ) {}
+
+    async execute(command: UpdateEvaluationTypeCommand): Promise<Either<EvaluationTypeError[], EvaluationType | undefined>> {
+        try {
+            const res = await this.evaluationTypeService.update(command.data);
+            return Right(res);
+        } catch (e) {
+            if (isAxiosError(e)) {
+                this.logger.error(JSON.stringify(e.response?.data));
+                const message = e.response?.data?.message;
+                const error = e.response?.data?.error;
+                if (message && error) {
+                    return Left([new EvaluationTypeError(error, message, error)]);
+                }
+            }
+            return Left([EvaluationTypeError.EVALUATION_TYPE_SERVICE_ERROR]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/gradingSystems/createGradingSystemUseCase.ts
+++ b/src/scolar/application/useCases/gradingSystems/createGradingSystemUseCase.ts
@@ -1,0 +1,57 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import { GradingSystem } from "@/scolar/domain/entities/grading_system";
+import { Either, Left, Right } from "purify-ts/Either";
+import { GRADING_SYSTEM_SERVICE } from "@/scolar/domain/symbols/GradingSystemSymbol";
+import { GradingSystemService } from "@/scolar/domain/services/GradingSystemService";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { GradingSystemError } from "@/scolar/domain/entities/GradingSystemError";
+import { inject, injectable } from "inversify";
+import Failure from "@/scolar/domain/failure";
+import { isAxiosError } from "axios";
+
+export class CreateGradingSystemCommand implements UseCaseCommand {
+    constructor(
+        private name: string,
+        private description: string,
+        private numberOfTerms: number,
+        private passingScore: string
+    ) {}
+
+    get data() {
+        return new GradingSystem(
+            0,
+            this.name,
+            this.description,
+            this.numberOfTerms,
+            this.passingScore
+        );
+    }
+}
+
+export type CreateGradingSystemUseCase = UseCase<GradingSystem, CreateGradingSystemCommand>;
+
+@injectable()
+export class CreateGradingSystemUseCaseImpl implements CreateGradingSystemUseCase {
+    constructor(
+        @inject(GRADING_SYSTEM_SERVICE) private gradingSystemService: GradingSystemService,
+        @inject(LOGGER) private logger: Logger
+    ) {}
+
+    async execute(command: CreateGradingSystemCommand): Promise<Either<Failure[], GradingSystem | undefined>> {
+        try {
+            const res = await this.gradingSystemService.create(command.data);
+            return Right(res);
+        } catch (e) {
+            if (isAxiosError(e)) {
+                this.logger.error(JSON.stringify(e.response?.data));
+                const message = e.response?.data?.message;
+                const error = e.response?.data?.error;
+                if (message && error) {
+                    return Left([new GradingSystemError(error, message, error)]);
+                }
+            }
+            return Left([GradingSystemError.GRADING_SYSTEM_SERVICE_ERROR]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/gradingSystems/deleteGradingSystemUseCase.ts
+++ b/src/scolar/application/useCases/gradingSystems/deleteGradingSystemUseCase.ts
@@ -1,0 +1,37 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import { Either, Left, Right } from "purify-ts/Either";
+import { GRADING_SYSTEM_SERVICE } from "@/scolar/domain/symbols/GradingSystemSymbol";
+import { GradingSystemService } from "@/scolar/domain/services/GradingSystemService";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+import { GradingSystemError } from "@/scolar/domain/entities/GradingSystemError";
+import { inject, injectable } from "inversify";
+
+export class DeleteGradingSystemCommand implements UseCaseCommand {
+    constructor(private id: number) {}
+
+    get data() {
+        return this.id;
+    }
+}
+
+export type DeleteGradingSystemUseCase = UseCase<void, DeleteGradingSystemCommand>;
+
+@injectable()
+export class DeleteGradingSystemUseCaseImpl implements DeleteGradingSystemUseCase {
+    constructor(
+        @inject(GRADING_SYSTEM_SERVICE) private gradingSystemService: GradingSystemService,
+        @inject(LOGGER) private logger: Logger
+    ) {}
+
+    async execute(command: DeleteGradingSystemCommand): Promise<Either<GradingSystemError[], void>> {
+        try {
+            const res = await this.gradingSystemService.delete(command.data);
+            return Right(res);
+        } catch (e) {
+            this.logger.error(JSON.stringify(e));
+            return Left([GradingSystemError.GRADING_SYSTEM_SERVICE_ERROR]);
+        }
+    }
+}
+

--- a/src/scolar/application/useCases/gradingSystems/getGradingSystemUseCase.ts
+++ b/src/scolar/application/useCases/gradingSystems/getGradingSystemUseCase.ts
@@ -1,0 +1,38 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import { GradingSystem } from "@/scolar/domain/entities/grading_system";
+import { GRADING_SYSTEM_SERVICE } from "@/scolar/domain/symbols/GradingSystemSymbol";
+import { GradingSystemService } from "@/scolar/domain/services/GradingSystemService";
+import { GradingSystemError } from "@/scolar/domain/entities/GradingSystemError";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+import { inject, injectable } from "inversify";
+import { Either, Left, Right } from "purify-ts/Either";
+
+export class GetGradingSystemCommand implements UseCaseCommand {
+    constructor(private id: number) {}
+
+    get data() {
+        return this.id;
+    }
+}
+
+export type GetGradingSystemUseCase = UseCase<GradingSystem, GetGradingSystemCommand>;
+
+@injectable()
+export class GetGradingSystemUseCaseImpl implements GetGradingSystemUseCase {
+    constructor(
+        @inject(GRADING_SYSTEM_SERVICE) private gradingSystemService: GradingSystemService,
+        @inject(LOGGER) private logger: Logger
+    ) {}
+
+    async execute(command: GetGradingSystemCommand): Promise<Either<GradingSystemError[], GradingSystem | undefined>> {
+        try {
+            const result = await this.gradingSystemService.get(command.data);
+            return Right(result);
+        } catch (e) {
+            this.logger.error(JSON.stringify(e));
+            return Left([GradingSystemError.GRADING_SYSTEM_SERVICE_ERROR]);
+        }
+    }
+}
+

--- a/src/scolar/application/useCases/gradingSystems/listGradingSystemUseCase.ts
+++ b/src/scolar/application/useCases/gradingSystems/listGradingSystemUseCase.ts
@@ -1,0 +1,36 @@
+import { PaginateUseCaseCommand, UseCase } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { GradingSystem } from "@/scolar/domain/entities/grading_system";
+import { GRADING_SYSTEM_SERVICE } from "@/scolar/domain/symbols/GradingSystemSymbol";
+import { GradingSystemService } from "@/scolar/domain/services/GradingSystemService";
+import { extractErrorMessage } from "@/lib/utils";
+import { inject, injectable } from "inversify";
+import { Either, Left, Right } from "purify-ts/Either";
+
+export class ListGradingSystemCommand extends PaginateUseCaseCommand {}
+
+export type ListGradingSystemUseCase = UseCase<PaginatedResult<GradingSystem>, ListGradingSystemCommand>;
+
+@injectable()
+export class ListGradingSystemUseCaseImpl implements ListGradingSystemUseCase {
+    constructor(
+        @inject(GRADING_SYSTEM_SERVICE) private gradingSystemService: GradingSystemService
+    ) {}
+
+    async execute(command: ListGradingSystemCommand): Promise<Either<Failure[], PaginatedResult<GradingSystem> | undefined>> {
+        try {
+            const result = await this.gradingSystemService.all(
+                command.data.page,
+                command.data.perPage,
+                command.data.search,
+                command.data.orderBy
+            );
+            return Right(result);
+        } catch (error) {
+            const _error = extractErrorMessage(error);
+            return Left([_error]);
+        }
+    }
+}
+

--- a/src/scolar/application/useCases/gradingSystems/updateGradingSystemUseCase.ts
+++ b/src/scolar/application/useCases/gradingSystems/updateGradingSystemUseCase.ts
@@ -1,0 +1,58 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import { GradingSystem } from "@/scolar/domain/entities/grading_system";
+import { Either, Left, Right } from "purify-ts/Either";
+import { GRADING_SYSTEM_SERVICE } from "@/scolar/domain/symbols/GradingSystemSymbol";
+import { GradingSystemService } from "@/scolar/domain/services/GradingSystemService";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+import { GradingSystemError } from "@/scolar/domain/entities/GradingSystemError";
+import { inject, injectable } from "inversify";
+import { isAxiosError } from "axios";
+
+export class UpdateGradingSystemCommand implements UseCaseCommand {
+    constructor(
+        private id: number,
+        private name: string,
+        private description: string,
+        private numberOfTerms: number,
+        private passingScore: string
+    ) {}
+
+    get data() {
+        return new GradingSystem(
+            this.id,
+            this.name,
+            this.description,
+            this.numberOfTerms,
+            this.passingScore
+        );
+    }
+}
+
+export type UpdateGradingSystemUseCase = UseCase<GradingSystem, UpdateGradingSystemCommand>;
+
+@injectable()
+export class UpdateGradingSystemUseCaseImpl implements UpdateGradingSystemUseCase {
+    constructor(
+        @inject(GRADING_SYSTEM_SERVICE) private gradingSystemService: GradingSystemService,
+        @inject(LOGGER) private logger: Logger
+    ) {}
+
+    async execute(command: UpdateGradingSystemCommand): Promise<Either<GradingSystemError[], GradingSystem | undefined>> {
+        try {
+            const res = await this.gradingSystemService.update(command.data);
+            return Right(res);
+        } catch (e) {
+            if (isAxiosError(e)) {
+                this.logger.error(JSON.stringify(e.response?.data));
+                const message = e.response?.data?.message;
+                const error = e.response?.data?.error;
+                if (message && error) {
+                    return Left([new GradingSystemError(error, message, error)]);
+                }
+            }
+            return Left([GradingSystemError.GRADING_SYSTEM_SERVICE_ERROR]);
+        }
+    }
+}
+

--- a/src/scolar/application/useCases/gradingTerms/createGradingTermUseCase.ts
+++ b/src/scolar/application/useCases/gradingTerms/createGradingTermUseCase.ts
@@ -1,0 +1,59 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import { GradingTerm } from "@/scolar/domain/entities/grading_term";
+import { Either, Left, Right } from "purify-ts/Either";
+import { GRADING_TERM_SERVICE } from "@/scolar/domain/symbols/GradingTermSymbol";
+import { GradingTermService } from "@/scolar/domain/services/GradingTermService";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { GradingTermError } from "@/scolar/domain/entities/GradingTermError";
+import { inject, injectable } from "inversify";
+import Failure from "@/scolar/domain/failure";
+import { isAxiosError } from "axios";
+
+export class CreateGradingTermCommand implements UseCaseCommand {
+    constructor(
+        private gradingSystem_id: number,
+        private academicYear_id: number,
+        private name: string,
+        private order: number,
+        private weight: string
+    ) {}
+
+    get data() {
+        return new GradingTerm(
+            0,
+            this.gradingSystem_id,
+            this.academicYear_id,
+            this.name,
+            this.order,
+            this.weight
+        );
+    }
+}
+
+export type CreateGradingTermUseCase = UseCase<GradingTerm, CreateGradingTermCommand>;
+
+@injectable()
+export class CreateGradingTermUseCaseImpl implements CreateGradingTermUseCase {
+    constructor(
+        @inject(GRADING_TERM_SERVICE) private gradingTermService: GradingTermService,
+        @inject(LOGGER) private logger: Logger
+    ) {}
+
+    async execute(command: CreateGradingTermCommand): Promise<Either<Failure[], GradingTerm | undefined>> {
+        try {
+            const res = await this.gradingTermService.create(command.data);
+            return Right(res);
+        } catch (e) {
+            if (isAxiosError(e)) {
+                this.logger.error(JSON.stringify(e.response?.data));
+                const message = e.response?.data?.message;
+                const error = e.response?.data?.error;
+                if (message && error) {
+                    return Left([new GradingTermError(error, message, error)]);
+                }
+            }
+            return Left([GradingTermError.GRADING_TERM_SERVICE_ERROR]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/gradingTerms/deleteGradingTermUseCase.ts
+++ b/src/scolar/application/useCases/gradingTerms/deleteGradingTermUseCase.ts
@@ -1,0 +1,36 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import { Either, Left, Right } from "purify-ts/Either";
+import { GRADING_TERM_SERVICE } from "@/scolar/domain/symbols/GradingTermSymbol";
+import { GradingTermService } from "@/scolar/domain/services/GradingTermService";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+import { GradingTermError } from "@/scolar/domain/entities/GradingTermError";
+import { inject, injectable } from "inversify";
+
+export class DeleteGradingTermCommand implements UseCaseCommand {
+    constructor(private id: number) {}
+
+    get data() {
+        return this.id;
+    }
+}
+
+export type DeleteGradingTermUseCase = UseCase<void, DeleteGradingTermCommand>;
+
+@injectable()
+export class DeleteGradingTermUseCaseImpl implements DeleteGradingTermUseCase {
+    constructor(
+        @inject(GRADING_TERM_SERVICE) private gradingTermService: GradingTermService,
+        @inject(LOGGER) private logger: Logger
+    ) {}
+
+    async execute(command: DeleteGradingTermCommand): Promise<Either<GradingTermError[], void>> {
+        try {
+            const res = await this.gradingTermService.delete(command.data);
+            return Right(res);
+        } catch (e) {
+            this.logger.error(JSON.stringify(e));
+            return Left([GradingTermError.GRADING_TERM_SERVICE_ERROR]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/gradingTerms/getGradingTermUseCase.ts
+++ b/src/scolar/application/useCases/gradingTerms/getGradingTermUseCase.ts
@@ -1,0 +1,37 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import { GradingTerm } from "@/scolar/domain/entities/grading_term";
+import { GRADING_TERM_SERVICE } from "@/scolar/domain/symbols/GradingTermSymbol";
+import { GradingTermService } from "@/scolar/domain/services/GradingTermService";
+import { GradingTermError } from "@/scolar/domain/entities/GradingTermError";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+import { inject, injectable } from "inversify";
+import { Either, Left, Right } from "purify-ts/Either";
+
+export class GetGradingTermCommand implements UseCaseCommand {
+    constructor(private id: number) {}
+
+    get data() {
+        return this.id;
+    }
+}
+
+export type GetGradingTermUseCase = UseCase<GradingTerm, GetGradingTermCommand>;
+
+@injectable()
+export class GetGradingTermUseCaseImpl implements GetGradingTermUseCase {
+    constructor(
+        @inject(GRADING_TERM_SERVICE) private gradingTermService: GradingTermService,
+        @inject(LOGGER) private logger: Logger
+    ) {}
+
+    async execute(command: GetGradingTermCommand): Promise<Either<GradingTermError[], GradingTerm | undefined>> {
+        try {
+            const result = await this.gradingTermService.get(command.data);
+            return Right(result);
+        } catch (e) {
+            this.logger.error(JSON.stringify(e));
+            return Left([GradingTermError.GRADING_TERM_SERVICE_ERROR]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/gradingTerms/listGradingTermUseCase.ts
+++ b/src/scolar/application/useCases/gradingTerms/listGradingTermUseCase.ts
@@ -1,0 +1,35 @@
+import { PaginateUseCaseCommand, UseCase } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { GradingTerm } from "@/scolar/domain/entities/grading_term";
+import { GRADING_TERM_SERVICE } from "@/scolar/domain/symbols/GradingTermSymbol";
+import { GradingTermService } from "@/scolar/domain/services/GradingTermService";
+import { extractErrorMessage } from "@/lib/utils";
+import { inject, injectable } from "inversify";
+import { Either, Left, Right } from "purify-ts/Either";
+
+export class ListGradingTermCommand extends PaginateUseCaseCommand {}
+
+export type ListGradingTermUseCase = UseCase<PaginatedResult<GradingTerm>, ListGradingTermCommand>;
+
+@injectable()
+export class ListGradingTermUseCaseImpl implements ListGradingTermUseCase {
+    constructor(
+        @inject(GRADING_TERM_SERVICE) private gradingTermService: GradingTermService
+    ) {}
+
+    async execute(command: ListGradingTermCommand): Promise<Either<Failure[], PaginatedResult<GradingTerm> | undefined>> {
+        try {
+            const result = await this.gradingTermService.all(
+                command.data.page,
+                command.data.perPage,
+                command.data.search,
+                command.data.orderBy
+            );
+            return Right(result);
+        } catch (error) {
+            const _error = extractErrorMessage(error);
+            return Left([_error]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/gradingTerms/updateGradingTermUseCase.ts
+++ b/src/scolar/application/useCases/gradingTerms/updateGradingTermUseCase.ts
@@ -1,0 +1,59 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import { GradingTerm } from "@/scolar/domain/entities/grading_term";
+import { Either, Left, Right } from "purify-ts/Either";
+import { GRADING_TERM_SERVICE } from "@/scolar/domain/symbols/GradingTermSymbol";
+import { GradingTermService } from "@/scolar/domain/services/GradingTermService";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+import { GradingTermError } from "@/scolar/domain/entities/GradingTermError";
+import { inject, injectable } from "inversify";
+import { isAxiosError } from "axios";
+
+export class UpdateGradingTermCommand implements UseCaseCommand {
+    constructor(
+        private id: number,
+        private gradingSystem_id: number,
+        private academicYear_id: number,
+        private name: string,
+        private order: number,
+        private weight: string
+    ) {}
+
+    get data() {
+        return new GradingTerm(
+            this.id,
+            this.gradingSystem_id,
+            this.academicYear_id,
+            this.name,
+            this.order,
+            this.weight
+        );
+    }
+}
+
+export type UpdateGradingTermUseCase = UseCase<GradingTerm, UpdateGradingTermCommand>;
+
+@injectable()
+export class UpdateGradingTermUseCaseImpl implements UpdateGradingTermUseCase {
+    constructor(
+        @inject(GRADING_TERM_SERVICE) private gradingTermService: GradingTermService,
+        @inject(LOGGER) private logger: Logger
+    ) {}
+
+    async execute(command: UpdateGradingTermCommand): Promise<Either<GradingTermError[], GradingTerm | undefined>> {
+        try {
+            const res = await this.gradingTermService.update(command.data);
+            return Right(res);
+        } catch (e) {
+            if (isAxiosError(e)) {
+                this.logger.error(JSON.stringify(e.response?.data));
+                const message = e.response?.data?.message;
+                const error = e.response?.data?.error;
+                if (message && error) {
+                    return Left([new GradingTermError(error, message, error)]);
+                }
+            }
+            return Left([GradingTermError.GRADING_TERM_SERVICE_ERROR]);
+        }
+    }
+}

--- a/src/scolar/domain/entities/EvaluationTypeError.ts
+++ b/src/scolar/domain/entities/EvaluationTypeError.ts
@@ -1,0 +1,9 @@
+import { AbstractFailure } from "../failure";
+
+export class EvaluationTypeError extends AbstractFailure {
+    static EVALUATION_TYPE_SERVICE_ERROR = new EvaluationTypeError(
+        'EvaluationTypeServiceError',
+        'Evaluation type service error',
+        'root'
+    );
+}

--- a/src/scolar/domain/entities/GradingSystemError.ts
+++ b/src/scolar/domain/entities/GradingSystemError.ts
@@ -1,0 +1,5 @@
+import { AbstractFailure } from "../failure";
+
+export class GradingSystemError extends AbstractFailure {
+    static GRADING_SYSTEM_SERVICE_ERROR = new GradingSystemError('GradingSystemServiceError', 'Grading system service error', 'root');
+}

--- a/src/scolar/domain/entities/GradingTermError.ts
+++ b/src/scolar/domain/entities/GradingTermError.ts
@@ -1,0 +1,9 @@
+import { AbstractFailure } from "../failure";
+
+export class GradingTermError extends AbstractFailure {
+    static GRADING_TERM_SERVICE_ERROR = new GradingTermError(
+        'GradingTermServiceError',
+        'Grading term service error',
+        'root'
+    );
+}

--- a/src/scolar/domain/entities/evaluation_type.ts
+++ b/src/scolar/domain/entities/evaluation_type.ts
@@ -1,0 +1,8 @@
+export class EvaluationType {
+    constructor(
+        public id: number,
+        public name: string,
+        public description: string,
+        public weight: string
+    ) {}
+}

--- a/src/scolar/domain/entities/grading_system.ts
+++ b/src/scolar/domain/entities/grading_system.ts
@@ -1,0 +1,9 @@
+export class GradingSystem {
+    constructor(
+        public id: number,
+        public name: string,
+        public description: string,
+        public numberOfTerms: number,
+        public passingScore: string
+    ) {}
+}

--- a/src/scolar/domain/entities/grading_term.ts
+++ b/src/scolar/domain/entities/grading_term.ts
@@ -1,0 +1,10 @@
+export class GradingTerm {
+    constructor(
+        public id: number,
+        public gradingSystem_id: number,
+        public academicYear_id: number,
+        public name: string,
+        public order: number,
+        public weight: string
+    ) {}
+}

--- a/src/scolar/domain/inversify.ts
+++ b/src/scolar/domain/inversify.ts
@@ -12,6 +12,22 @@ import { SECTION_LIST_USE_CASE, SECTION_REPOSITORY, SECTION_SERVICE } from "./sy
 import { SectionRepositoryImpl } from "../infrastructure/adapters/api/SectionRepositoryImpl";
 import { SUBJECT_CREATE_USE_CASE, SUBJECT_LIST_USE_CASE, SUBJECT_REPOSITORY, SUBJECT_SERVICE } from "./symbols/SubjectSymbol";
 import { SubjectRepositoryImpl } from "../infrastructure/adapters/api/SubjectRepositoryImpl";
+import { GRADING_SYSTEM_CREATE_USECASE, GRADING_SYSTEM_DELETE_USECASE, GRADING_SYSTEM_GET_USECASE, GRADING_SYSTEM_LIST_USECASE, GRADING_SYSTEM_REPOSITORY, GRADING_SYSTEM_SERVICE, GRADING_SYSTEM_UPDATE_USECASE } from "./symbols/GradingSystemSymbol";
+import { GradingSystemRepositoryImpl } from "../infrastructure/adapters/api/GradingSystemRepositoryImpl";
+import { GradingSystemService } from "./services/GradingSystemService";
+import { CreateGradingSystemUseCaseImpl } from "../application/useCases/gradingSystems/createGradingSystemUseCase";
+import { ListGradingSystemUseCaseImpl } from "../application/useCases/gradingSystems/listGradingSystemUseCase";
+import { GetGradingSystemUseCaseImpl } from "../application/useCases/gradingSystems/getGradingSystemUseCase";
+import { UpdateGradingSystemUseCaseImpl } from "../application/useCases/gradingSystems/updateGradingSystemUseCase";
+import { DeleteGradingSystemUseCaseImpl } from "../application/useCases/gradingSystems/deleteGradingSystemUseCase";
+import { GRADING_TERM_CREATE_USECASE, GRADING_TERM_DELETE_USECASE, GRADING_TERM_GET_USECASE, GRADING_TERM_LIST_USECASE, GRADING_TERM_REPOSITORY, GRADING_TERM_SERVICE, GRADING_TERM_UPDATE_USECASE } from "./symbols/GradingTermSymbol";
+import { GradingTermRepositoryImpl } from "../infrastructure/adapters/api/GradingTermRepositoryImpl";
+import { GradingTermService } from "./services/GradingTermService";
+import { CreateGradingTermUseCaseImpl } from "../application/useCases/gradingTerms/createGradingTermUseCase";
+import { ListGradingTermUseCaseImpl } from "../application/useCases/gradingTerms/listGradingTermUseCase";
+import { GetGradingTermUseCaseImpl } from "../application/useCases/gradingTerms/getGradingTermUseCase";
+import { UpdateGradingTermUseCaseImpl } from "../application/useCases/gradingTerms/updateGradingTermUseCase";
+import { DeleteGradingTermUseCaseImpl } from "../application/useCases/gradingTerms/deleteGradingTermUseCase";
 import { LevelService } from "./services/LevelService";
 import { ListLevelsUsecaseImpl } from "../application/useCases/levels/listLevelsUseCase";
 import schoolapi from "../infrastructure/services/Api";
@@ -78,8 +94,28 @@ const contianerScolar = new ContainerModule(
         bind(SUBJECT_REPOSITORY).toDynamicValue(() => {
             return new SubjectRepositoryImpl(schoolapi);
         })
+        bind(GRADING_SYSTEM_REPOSITORY).toDynamicValue(() => {
+            return new GradingSystemRepositoryImpl(schoolapi);
+        })
+        bind(GRADING_TERM_REPOSITORY).toDynamicValue(() => {
+            return new GradingTermRepositoryImpl(schoolapi);
+        })
         bind(SECTION_SERVICE).to(SectionService)
         bind(SECTION_LIST_USE_CASE).to(ListSectionUseCaseImpl)
+
+        bind(GRADING_SYSTEM_SERVICE).to(GradingSystemService);
+        bind(GRADING_SYSTEM_CREATE_USECASE).to(CreateGradingSystemUseCaseImpl);
+        bind(GRADING_SYSTEM_LIST_USECASE).to(ListGradingSystemUseCaseImpl);
+        bind(GRADING_SYSTEM_GET_USECASE).to(GetGradingSystemUseCaseImpl);
+        bind(GRADING_SYSTEM_UPDATE_USECASE).to(UpdateGradingSystemUseCaseImpl);
+        bind(GRADING_SYSTEM_DELETE_USECASE).to(DeleteGradingSystemUseCaseImpl);
+
+        bind(GRADING_TERM_SERVICE).to(GradingTermService);
+        bind(GRADING_TERM_CREATE_USECASE).to(CreateGradingTermUseCaseImpl);
+        bind(GRADING_TERM_LIST_USECASE).to(ListGradingTermUseCaseImpl);
+        bind(GRADING_TERM_GET_USECASE).to(GetGradingTermUseCaseImpl);
+        bind(GRADING_TERM_UPDATE_USECASE).to(UpdateGradingTermUseCaseImpl);
+        bind(GRADING_TERM_DELETE_USECASE).to(DeleteGradingTermUseCaseImpl);
 
 
         bind(LEVEL_SERVICE).to(LevelService)

--- a/src/scolar/domain/inversify.ts
+++ b/src/scolar/domain/inversify.ts
@@ -28,6 +28,14 @@ import { ListGradingTermUseCaseImpl } from "../application/useCases/gradingTerms
 import { GetGradingTermUseCaseImpl } from "../application/useCases/gradingTerms/getGradingTermUseCase";
 import { UpdateGradingTermUseCaseImpl } from "../application/useCases/gradingTerms/updateGradingTermUseCase";
 import { DeleteGradingTermUseCaseImpl } from "../application/useCases/gradingTerms/deleteGradingTermUseCase";
+import { EVALUATION_TYPE_CREATE_USECASE, EVALUATION_TYPE_DELETE_USECASE, EVALUATION_TYPE_GET_USECASE, EVALUATION_TYPE_LIST_USECASE, EVALUATION_TYPE_REPOSITORY, EVALUATION_TYPE_SERVICE, EVALUATION_TYPE_UPDATE_USECASE } from "./symbols/EvaluationTypeSymbol";
+import { EvaluationTypeRepositoryImpl } from "../infrastructure/adapters/api/EvaluationTypeRepositoryImpl";
+import { EvaluationTypeService } from "./services/EvaluationTypeService";
+import { CreateEvaluationTypeUseCaseImpl } from "../application/useCases/evaluationTypes/createEvaluationTypeUseCase";
+import { ListEvaluationTypeUseCaseImpl } from "../application/useCases/evaluationTypes/listEvaluationTypeUseCase";
+import { GetEvaluationTypeUseCaseImpl } from "../application/useCases/evaluationTypes/getEvaluationTypeUseCase";
+import { UpdateEvaluationTypeUseCaseImpl } from "../application/useCases/evaluationTypes/updateEvaluationTypeUseCase";
+import { DeleteEvaluationTypeUseCaseImpl } from "../application/useCases/evaluationTypes/deleteEvaluationTypeUseCase";
 import { LevelService } from "./services/LevelService";
 import { ListLevelsUsecaseImpl } from "../application/useCases/levels/listLevelsUseCase";
 import schoolapi from "../infrastructure/services/Api";
@@ -100,6 +108,9 @@ const contianerScolar = new ContainerModule(
         bind(GRADING_TERM_REPOSITORY).toDynamicValue(() => {
             return new GradingTermRepositoryImpl(schoolapi);
         })
+        bind(EVALUATION_TYPE_REPOSITORY).toDynamicValue(() => {
+            return new EvaluationTypeRepositoryImpl(schoolapi);
+        })
         bind(SECTION_SERVICE).to(SectionService)
         bind(SECTION_LIST_USE_CASE).to(ListSectionUseCaseImpl)
 
@@ -117,6 +128,12 @@ const contianerScolar = new ContainerModule(
         bind(GRADING_TERM_UPDATE_USECASE).to(UpdateGradingTermUseCaseImpl);
         bind(GRADING_TERM_DELETE_USECASE).to(DeleteGradingTermUseCaseImpl);
 
+        bind(EVALUATION_TYPE_SERVICE).to(EvaluationTypeService);
+        bind(EVALUATION_TYPE_CREATE_USECASE).to(CreateEvaluationTypeUseCaseImpl);
+        bind(EVALUATION_TYPE_LIST_USECASE).to(ListEvaluationTypeUseCaseImpl);
+        bind(EVALUATION_TYPE_GET_USECASE).to(GetEvaluationTypeUseCaseImpl);
+        bind(EVALUATION_TYPE_UPDATE_USECASE).to(UpdateEvaluationTypeUseCaseImpl);
+        bind(EVALUATION_TYPE_DELETE_USECASE).to(DeleteEvaluationTypeUseCaseImpl);
 
         bind(LEVEL_SERVICE).to(LevelService)
         bind(LEVEL_LIST_USECASE).to(ListLevelsUsecaseImpl)
@@ -127,13 +144,12 @@ const contianerScolar = new ContainerModule(
         bind(COURSE_SUBJECT_SERVICE).to(CourseSubjetService)
 
         bind(COURSE_SERVICE).to(CourseService);
-        bind(COURSE_LIST_USECASE).to(ListCoursesUseCaseImpl);   
-        
+        bind(COURSE_LIST_USECASE).to(ListCoursesUseCaseImpl);
 
         bind(SUBJECT_SERVICE).to(SubjectService);
         bind(SUBJECT_LIST_USE_CASE).to(ListSubjectUseCaseImpl)
         bind(SUBJECT_CREATE_USE_CASE).to(CreateSubjectUseCaseImpl)
-        
+
         bind(COURSE_CREATE_USECASE).to(CreateCourseUseCaseImpl);
         bind(COURSE_DELETE_USECASE).to(DeleteCourseUseCaseImpl)
         bind(COURSE_UPDATE_USECASE).to(UpdateCourseUseCaseImpl)
@@ -147,7 +163,7 @@ const contianerScolar = new ContainerModule(
         bind(SCHOOL_YEAR_UPDATE_USE_CASE).to(UpdateSchoolYearUseCaseImpl)
         bind(SCHOOL_YEAR_GET_USE_CASE).to(GetSchoolYearUseCaseImpl);
         bind(SCHOOL_YEAR_DELETE_USE_CASE).to(DeleteSchoolYearUseCaseImpl);
-        
+
         bind(PARALLEL_SERVICE).to(ParallelService);
         bind(PARALLEL_LIST_USECASE).to(ListParallelUseCaseImpl)
         bind(PARALLEL_CREATE_USECASE).to(CreateParallelUseCaseImpl)
@@ -157,6 +173,4 @@ const contianerScolar = new ContainerModule(
     }
 );
 
-
-
-export { contianerScolar  };
+export { contianerScolar };

--- a/src/scolar/domain/mappers/EvaluationTypeMapper.ts
+++ b/src/scolar/domain/mappers/EvaluationTypeMapper.ts
@@ -1,0 +1,21 @@
+import { EvaluationTypeDto } from "@/scolar/infrastructure/dto/EvaluationTypeDto";
+import { EvaluationType } from "../entities/evaluation_type";
+
+export class EvaluationTypeMapper {
+    static toDomain(et: EvaluationTypeDto): EvaluationType {
+        return new EvaluationType(
+            et.id,
+            et.name,
+            et.description,
+            et.weight
+        );
+    }
+
+    static toDto(et: EvaluationType): Omit<EvaluationTypeDto, 'id'> {
+        return {
+            name: et.name,
+            description: et.description,
+            weight: et.weight
+        };
+    }
+}

--- a/src/scolar/domain/mappers/GradingSystemMapper.ts
+++ b/src/scolar/domain/mappers/GradingSystemMapper.ts
@@ -1,0 +1,23 @@
+import { GradingSystemDto } from "@/scolar/infrastructure/dto/GradingSystemDto";
+import { GradingSystem } from "../entities/grading_system";
+
+export class GradingSystemMapper {
+    static toDomain(gs: GradingSystemDto): GradingSystem {
+        return new GradingSystem(
+            gs.id,
+            gs.name,
+            gs.description,
+            gs.numberOfTerms,
+            gs.passingScore
+        );
+    }
+
+    static toDto(gs: GradingSystem): Omit<GradingSystemDto, 'id'> {
+        return {
+            name: gs.name,
+            description: gs.description,
+            numberOfTerms: gs.numberOfTerms,
+            passingScore: gs.passingScore
+        };
+    }
+}

--- a/src/scolar/domain/mappers/GradingTermMapper.ts
+++ b/src/scolar/domain/mappers/GradingTermMapper.ts
@@ -1,0 +1,25 @@
+import { GradingTermDto } from "@/scolar/infrastructure/dto/GradingTermDto";
+import { GradingTerm } from "../entities/grading_term";
+
+export class GradingTermMapper {
+    static toDomain(gt: GradingTermDto): GradingTerm {
+        return new GradingTerm(
+            gt.id,
+            gt.gradingSystem_id,
+            gt.academicYear_id,
+            gt.name,
+            gt.order,
+            gt.weight
+        );
+    }
+
+    static toDto(gt: GradingTerm): Omit<GradingTermDto, 'id'> {
+        return {
+            gradingSystem_id: gt.gradingSystem_id,
+            academicYear_id: gt.academicYear_id,
+            name: gt.name,
+            order: gt.order,
+            weight: gt.weight
+        };
+    }
+}

--- a/src/scolar/domain/repositories/EvaluationTypeRepository.ts
+++ b/src/scolar/domain/repositories/EvaluationTypeRepository.ts
@@ -1,0 +1,10 @@
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { EvaluationTypeDto } from "@/scolar/infrastructure/dto/EvaluationTypeDto";
+
+export interface EvaluationTypeRepository {
+    create(data: Omit<EvaluationTypeDto, 'id'>): Promise<EvaluationTypeDto>;
+    update(id: number, data: Omit<EvaluationTypeDto, 'id'>): Promise<EvaluationTypeDto>;
+    delete(id: number): Promise<void>;
+    findAll(page: number, limit: number, search?: string, orderby?: string[]): Promise<PaginatedResult<EvaluationTypeDto>>;
+    findById(id: number): Promise<EvaluationTypeDto>;
+}

--- a/src/scolar/domain/repositories/GradingSystemRepository.ts
+++ b/src/scolar/domain/repositories/GradingSystemRepository.ts
@@ -1,0 +1,10 @@
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { GradingSystemDto } from "@/scolar/infrastructure/dto/GradingSystemDto";
+
+export interface GradingSystemRepository {
+    create(data: Omit<GradingSystemDto, 'id'>): Promise<GradingSystemDto>;
+    update(id: number, data: Omit<GradingSystemDto, 'id'>): Promise<GradingSystemDto>;
+    delete(id: number): Promise<void>;
+    findAll(page: number, limit: number, search?: string, orderby?: string[]): Promise<PaginatedResult<GradingSystemDto>>;
+    findById(id: number): Promise<GradingSystemDto>;
+}

--- a/src/scolar/domain/repositories/GradingTermRepository.ts
+++ b/src/scolar/domain/repositories/GradingTermRepository.ts
@@ -1,0 +1,10 @@
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { GradingTermDto } from "@/scolar/infrastructure/dto/GradingTermDto";
+
+export interface GradingTermRepository {
+    create(data: Omit<GradingTermDto, 'id'>): Promise<GradingTermDto>;
+    update(id: number, data: Omit<GradingTermDto, 'id'>): Promise<GradingTermDto>;
+    delete(id: number): Promise<void>;
+    findAll(page: number, limit: number, search?: string, orderby?: string[]): Promise<PaginatedResult<GradingTermDto>>;
+    findById(id: number): Promise<GradingTermDto>;
+}

--- a/src/scolar/domain/services/EvaluationTypeService.ts
+++ b/src/scolar/domain/services/EvaluationTypeService.ts
@@ -1,0 +1,42 @@
+import { EvaluationTypeRepository } from "../repositories/EvaluationTypeRepository";
+import { inject, injectable } from "inversify";
+import { EVALUATION_TYPE_REPOSITORY } from "../symbols/EvaluationTypeSymbol";
+import { EvaluationTypeMapper } from "../mappers/EvaluationTypeMapper";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { EvaluationType } from "../entities/evaluation_type";
+
+@injectable()
+export class EvaluationTypeService {
+    constructor(
+        @inject(EVALUATION_TYPE_REPOSITORY)
+        private repository: EvaluationTypeRepository
+    ) {}
+
+    async all(page: number, size: number, search?: string, order?: string[]) {
+        const res = await this.repository.findAll(page, size, search, order);
+        return {
+            ...res,
+            data: res.data.map(EvaluationTypeMapper.toDomain)
+        } as PaginatedResult<EvaluationType>;
+    }
+
+    async get(id: number) {
+        const res = await this.repository.findById(id);
+        return EvaluationTypeMapper.toDomain(res);
+    }
+
+    async create(et: EvaluationType) {
+        const res = await this.repository.create(EvaluationTypeMapper.toDto(et));
+        return EvaluationTypeMapper.toDomain(res);
+    }
+
+    async update(et: EvaluationType) {
+        const res = await this.repository.update(et.id, EvaluationTypeMapper.toDto(et));
+        return EvaluationTypeMapper.toDomain(res);
+    }
+
+    async delete(id: number) {
+        const res = await this.repository.delete(id);
+        return res;
+    }
+}

--- a/src/scolar/domain/services/GradingSystemService.ts
+++ b/src/scolar/domain/services/GradingSystemService.ts
@@ -1,0 +1,42 @@
+import { GradingSystemRepository } from "../repositories/GradingSystemRepository";
+import { inject, injectable } from "inversify";
+import { GRADING_SYSTEM_REPOSITORY } from "../symbols/GradingSystemSymbol";
+import { GradingSystemMapper } from "../mappers/GradingSystemMapper";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { GradingSystem } from "../entities/grading_system";
+
+@injectable()
+export class GradingSystemService {
+    constructor(
+        @inject(GRADING_SYSTEM_REPOSITORY)
+        private repository: GradingSystemRepository
+    ) {}
+
+    async all(page: number, size: number, search?: string, order?: string[]) {
+        const res = await this.repository.findAll(page, size, search, order);
+        return {
+            ...res,
+            data: res.data.map(GradingSystemMapper.toDomain)
+        } as PaginatedResult<GradingSystem>;
+    }
+
+    async get(id: number) {
+        const res = await this.repository.findById(id);
+        return GradingSystemMapper.toDomain(res);
+    }
+
+    async create(gs: GradingSystem) {
+        const res = await this.repository.create(GradingSystemMapper.toDto(gs));
+        return GradingSystemMapper.toDomain(res);
+    }
+
+    async update(gs: GradingSystem) {
+        const res = await this.repository.update(gs.id, GradingSystemMapper.toDto(gs));
+        return GradingSystemMapper.toDomain(res);
+    }
+
+    async delete(id: number) {
+        const res = await this.repository.delete(id);
+        return res;
+    }
+}

--- a/src/scolar/domain/services/GradingTermService.ts
+++ b/src/scolar/domain/services/GradingTermService.ts
@@ -1,0 +1,42 @@
+import { GradingTermRepository } from "../repositories/GradingTermRepository";
+import { inject, injectable } from "inversify";
+import { GRADING_TERM_REPOSITORY } from "../symbols/GradingTermSymbol";
+import { GradingTermMapper } from "../mappers/GradingTermMapper";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { GradingTerm } from "../entities/grading_term";
+
+@injectable()
+export class GradingTermService {
+    constructor(
+        @inject(GRADING_TERM_REPOSITORY)
+        private repository: GradingTermRepository
+    ) {}
+
+    async all(page: number, size: number, search?: string, order?: string[]) {
+        const res = await this.repository.findAll(page, size, search, order);
+        return {
+            ...res,
+            data: res.data.map(GradingTermMapper.toDomain)
+        } as PaginatedResult<GradingTerm>;
+    }
+
+    async get(id: number) {
+        const res = await this.repository.findById(id);
+        return GradingTermMapper.toDomain(res);
+    }
+
+    async create(gt: GradingTerm) {
+        const res = await this.repository.create(GradingTermMapper.toDto(gt));
+        return GradingTermMapper.toDomain(res);
+    }
+
+    async update(gt: GradingTerm) {
+        const res = await this.repository.update(gt.id, GradingTermMapper.toDto(gt));
+        return GradingTermMapper.toDomain(res);
+    }
+
+    async delete(id: number) {
+        const res = await this.repository.delete(id);
+        return res;
+    }
+}

--- a/src/scolar/domain/symbols/EvaluationTypeSymbol.ts
+++ b/src/scolar/domain/symbols/EvaluationTypeSymbol.ts
@@ -1,0 +1,13 @@
+export const EVALUATION_TYPE_REPOSITORY = Symbol('EvaluationTypeRepository');
+
+export const EVALUATION_TYPE_SERVICE = Symbol('EvaluationTypeService');
+
+export const EVALUATION_TYPE_LIST_USECASE = Symbol('EvaluationTypeListUsecase');
+
+export const EVALUATION_TYPE_CREATE_USECASE = Symbol('EvaluationTypeCreateUsecase');
+
+export const EVALUATION_TYPE_GET_USECASE = Symbol('EvaluationTypeGetUsecase');
+
+export const EVALUATION_TYPE_UPDATE_USECASE = Symbol('EvaluationTypeUpdateUsecase');
+
+export const EVALUATION_TYPE_DELETE_USECASE = Symbol('EvaluationTypeDeleteUsecase');

--- a/src/scolar/domain/symbols/GradingSystemSymbol.ts
+++ b/src/scolar/domain/symbols/GradingSystemSymbol.ts
@@ -1,0 +1,13 @@
+export const GRADING_SYSTEM_REPOSITORY = Symbol('GradingSystemRepository');
+
+export const GRADING_SYSTEM_SERVICE = Symbol('GradingSystemService');
+
+export const GRADING_SYSTEM_LIST_USECASE = Symbol('GradingSystemListUsecase');
+
+export const GRADING_SYSTEM_CREATE_USECASE = Symbol('GradingSystemCreateUsecase');
+
+export const GRADING_SYSTEM_GET_USECASE = Symbol('GradingSystemGetUsecase');
+
+export const GRADING_SYSTEM_UPDATE_USECASE = Symbol('GradingSystemUpdateUsecase');
+
+export const GRADING_SYSTEM_DELETE_USECASE = Symbol('GradingSystemDeleteUsecase');

--- a/src/scolar/domain/symbols/GradingTermSymbol.ts
+++ b/src/scolar/domain/symbols/GradingTermSymbol.ts
@@ -1,0 +1,13 @@
+export const GRADING_TERM_REPOSITORY = Symbol('GradingTermRepository');
+
+export const GRADING_TERM_SERVICE = Symbol('GradingTermService');
+
+export const GRADING_TERM_LIST_USECASE = Symbol('GradingTermListUsecase');
+
+export const GRADING_TERM_CREATE_USECASE = Symbol('GradingTermCreateUsecase');
+
+export const GRADING_TERM_GET_USECASE = Symbol('GradingTermGetUsecase');
+
+export const GRADING_TERM_UPDATE_USECASE = Symbol('GradingTermUpdateUsecase');
+
+export const GRADING_TERM_DELETE_USECASE = Symbol('GradingTermDeleteUsecase');

--- a/src/scolar/infrastructure/adapters/api/EvaluationTypeRepositoryImpl.ts
+++ b/src/scolar/infrastructure/adapters/api/EvaluationTypeRepositoryImpl.ts
@@ -1,0 +1,44 @@
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { EvaluationTypeRepository } from "@/scolar/domain/repositories/EvaluationTypeRepository";
+import { EvaluationTypeDto } from "../../dto/EvaluationTypeDto";
+import { AxiosInstance } from "axios";
+import { injectable } from "inversify";
+
+@injectable()
+export class EvaluationTypeRepositoryImpl implements EvaluationTypeRepository {
+    private readonly api: AxiosInstance;
+    constructor(api: AxiosInstance) {
+        this.api = api;
+    }
+
+    async create(data: Omit<EvaluationTypeDto, 'id'>): Promise<EvaluationTypeDto> {
+        const response = await this.api.post<EvaluationTypeDto>("/evaluation-types/", data);
+        return response.data;
+    }
+
+    async update(id: number, data: Omit<EvaluationTypeDto, 'id'>): Promise<EvaluationTypeDto> {
+        const response = await this.api.put<EvaluationTypeDto>(`/evaluation-types/${id}`, data);
+        return response.data;
+    }
+
+    async delete(id: number): Promise<void> {
+        await this.api.delete(`/evaluation-types/${id}`);
+    }
+
+    async findAll(page: number, limit: number, search?: string, orderby?: string[]): Promise<PaginatedResult<EvaluationTypeDto>> {
+        const response = await this.api.get<PaginatedResult<EvaluationTypeDto>>("/evaluation-types/", {
+            params: {
+                page,
+                limit,
+                search,
+                orderby
+            }
+        });
+        return response.data;
+    }
+
+    async findById(id: number): Promise<EvaluationTypeDto> {
+        const response = await this.api.get<EvaluationTypeDto>(`/evaluation-types/${id}`);
+        return response.data;
+    }
+}

--- a/src/scolar/infrastructure/adapters/api/GradingSystemRepositoryImpl.ts
+++ b/src/scolar/infrastructure/adapters/api/GradingSystemRepositoryImpl.ts
@@ -1,0 +1,44 @@
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { GradingSystemRepository } from "@/scolar/domain/repositories/GradingSystemRepository";
+import { GradingSystemDto } from "../../dto/GradingSystemDto";
+import { AxiosInstance } from "axios";
+import { injectable } from "inversify";
+
+@injectable()
+export class GradingSystemRepositoryImpl implements GradingSystemRepository {
+    private readonly api: AxiosInstance;
+    constructor(api: AxiosInstance) {
+        this.api = api;
+    }
+
+    async create(data: Omit<GradingSystemDto, "id">): Promise<GradingSystemDto> {
+        const response = await this.api.post<GradingSystemDto>("/grading-systems/", data);
+        return response.data;
+    }
+
+    async update(id: number, data: Omit<GradingSystemDto, "id">): Promise<GradingSystemDto> {
+        const response = await this.api.put<GradingSystemDto>(`/grading-systems/${id}`, data);
+        return response.data;
+    }
+
+    async delete(id: number): Promise<void> {
+        await this.api.delete(`/grading-systems/${id}`);
+    }
+
+    async findAll(page: number, limit: number, search?: string, orderby?: string[]): Promise<PaginatedResult<GradingSystemDto>> {
+        const response = await this.api.get<PaginatedResult<GradingSystemDto>>("/grading-systems/", {
+            params: {
+                page,
+                limit,
+                search,
+                orderby
+            }
+        });
+        return response.data;
+    }
+
+    async findById(id: number): Promise<GradingSystemDto> {
+        const response = await this.api.get<GradingSystemDto>(`/grading-systems/${id}`);
+        return response.data;
+    }
+}

--- a/src/scolar/infrastructure/adapters/api/GradingTermRepositoryImpl.ts
+++ b/src/scolar/infrastructure/adapters/api/GradingTermRepositoryImpl.ts
@@ -1,0 +1,44 @@
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { GradingTermRepository } from "@/scolar/domain/repositories/GradingTermRepository";
+import { GradingTermDto } from "../../dto/GradingTermDto";
+import { AxiosInstance } from "axios";
+import { injectable } from "inversify";
+
+@injectable()
+export class GradingTermRepositoryImpl implements GradingTermRepository {
+    private readonly api: AxiosInstance;
+    constructor(api: AxiosInstance) {
+        this.api = api;
+    }
+
+    async create(data: Omit<GradingTermDto, 'id'>): Promise<GradingTermDto> {
+        const response = await this.api.post<GradingTermDto>("/grading-terms/", data);
+        return response.data;
+    }
+
+    async update(id: number, data: Omit<GradingTermDto, 'id'>): Promise<GradingTermDto> {
+        const response = await this.api.put<GradingTermDto>(`/grading-terms/${id}`, data);
+        return response.data;
+    }
+
+    async delete(id: number): Promise<void> {
+        await this.api.delete(`/grading-terms/${id}`);
+    }
+
+    async findAll(page: number, limit: number, search?: string, orderby?: string[]): Promise<PaginatedResult<GradingTermDto>> {
+        const response = await this.api.get<PaginatedResult<GradingTermDto>>("/grading-terms/", {
+            params: {
+                page,
+                limit,
+                search,
+                orderby
+            }
+        });
+        return response.data;
+    }
+
+    async findById(id: number): Promise<GradingTermDto> {
+        const response = await this.api.get<GradingTermDto>(`/grading-terms/${id}`);
+        return response.data;
+    }
+}

--- a/src/scolar/infrastructure/dto/EvaluationTypeDto.ts
+++ b/src/scolar/infrastructure/dto/EvaluationTypeDto.ts
@@ -1,0 +1,6 @@
+export interface EvaluationTypeDto {
+    id: number;
+    name: string;
+    description: string;
+    weight: string;
+}

--- a/src/scolar/infrastructure/dto/GradingSystemDto.ts
+++ b/src/scolar/infrastructure/dto/GradingSystemDto.ts
@@ -1,0 +1,7 @@
+export interface GradingSystemDto {
+    id: number;
+    name: string;
+    description: string;
+    numberOfTerms: number;
+    passingScore: string;
+}

--- a/src/scolar/infrastructure/dto/GradingTermDto.ts
+++ b/src/scolar/infrastructure/dto/GradingTermDto.ts
@@ -1,0 +1,8 @@
+export interface GradingTermDto {
+    id: number;
+    gradingSystem_id: number;
+    academicYear_id: number;
+    name: string;
+    order: number;
+    weight: string;
+}

--- a/src/scolar/presentation/ui/EvaluationType/Create/EvaluationTypeCreateContainer.tsx
+++ b/src/scolar/presentation/ui/EvaluationType/Create/EvaluationTypeCreateContainer.tsx
@@ -1,0 +1,65 @@
+import { useInjection } from "inversify-react";
+import { useNavigate } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { useTransition } from "react";
+import { toast } from "@/hooks/use-toast";
+import { EvaluationTypeCreatePresenter } from "./EvaluationTypeCreatePresenter";
+import { CreateEvaluationTypeUseCase, CreateEvaluationTypeCommand } from "@/scolar/application/useCases/evaluationTypes/createEvaluationTypeUseCase";
+import { EVALUATION_TYPE_CREATE_USECASE } from "@/scolar/domain/symbols/EvaluationTypeSymbol";
+
+interface FormValues {
+    data: {
+        name: string;
+        description: string;
+        weight: string;
+    }
+}
+
+export const EvaluationTypeCreateContainer = () => {
+    const navigate = useNavigate();
+    const [isPending, startTransition] = useTransition();
+    const createEvalType = useInjection<CreateEvaluationTypeUseCase>(EVALUATION_TYPE_CREATE_USECASE);
+    const { register, handleSubmit, formState: { errors }, watch } = useForm<FormValues>({
+        defaultValues: {
+            data: { name: "", description: "", weight: "" }
+        }
+    });
+
+    const formData = watch("data");
+
+    const onSubmit = (values: FormValues) => {
+        startTransition(async () => {
+            const command = new CreateEvaluationTypeCommand(values.data.name, values.data.description, values.data.weight);
+            const res = await createEvalType.execute(command);
+            if (res.isLeft()) {
+                const fail = res.extract();
+                toast({
+                    title: "Error",
+                    description: fail.map(f => f.getMessage()).join(", "),
+                    variant: "destructive",
+                });
+                return;
+            }
+            toast({
+                title: "Tipo de evaluación creado",
+                description: "El tipo de evaluación se creó correctamente",
+                variant: "success",
+            });
+            navigate('/tipos-evaluacion');
+        });
+    };
+
+    const onCancel = () => navigate('/tipos-evaluacion');
+
+    return (
+        <EvaluationTypeCreatePresenter
+            onSubmit={handleSubmit(onSubmit)}
+            register={register}
+            errors={errors}
+            isSubmitting={isPending}
+            onCancel={onCancel}
+            formData={formData}
+        />
+    );
+};
+

--- a/src/scolar/presentation/ui/EvaluationType/Create/EvaluationTypeCreatePresenter.tsx
+++ b/src/scolar/presentation/ui/EvaluationType/Create/EvaluationTypeCreatePresenter.tsx
@@ -1,0 +1,61 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+
+interface FormValues {
+    data: {
+        name: string;
+        description: string;
+        weight: string;
+    }
+}
+
+interface Props {
+    onSubmit: () => void;
+    onCancel: () => void;
+    register: UseFormRegister<FormValues>;
+    errors: FieldErrors<FormValues>;
+    isSubmitting: boolean;
+    formData: FormValues['data'];
+}
+
+export const EvaluationTypeCreatePresenter = ({ onSubmit, onCancel, register, errors, isSubmitting }: Props) => {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Nuevo Tipo de Evaluación</CardTitle>
+            </CardHeader>
+            <form onSubmit={onSubmit}>
+                <CardContent className="space-y-4">
+                    <div className="space-y-2">
+                        <Label htmlFor="name">Nombre</Label>
+                        <Input id="name" {...register('data.name', { required: true })} />
+                        {errors.data?.name && (<span className="text-red-500 text-sm">{errors.data.name.message}</span>)}
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="description">Descripción</Label>
+                        <Textarea id="description" {...register('data.description', { required: true })} />
+                        {errors.data?.description && (<span className="text-red-500 text-sm">{errors.data.description.message}</span>)}
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="weight">Peso</Label>
+                        <Input id="weight" {...register('data.weight', { required: true })} />
+                        {errors.data?.weight && (<span className="text-red-500 text-sm">{errors.data.weight.message}</span>)}
+                    </div>
+                </CardContent>
+                <CardFooter className="flex justify-between">
+                    <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>
+                        Cancelar
+                    </Button>
+                    <Button type="submit" disabled={isSubmitting}>
+                        {isSubmitting ? 'Guardando...' : 'Guardar'}
+                    </Button>
+                </CardFooter>
+            </form>
+        </Card>
+    );
+};
+

--- a/src/scolar/presentation/ui/EvaluationType/Delete/EvaluationTypeDeleteContainer.tsx
+++ b/src/scolar/presentation/ui/EvaluationType/Delete/EvaluationTypeDeleteContainer.tsx
@@ -1,0 +1,36 @@
+import { useInjection } from "inversify-react";
+import { toast } from "@/hooks/use-toast";
+import { EvaluationType } from "@/scolar/domain/entities/evaluation_type";
+import { EvaluationTypeDeletePresenter } from "./EvaluationTypeDeletePresenter";
+import { DeleteEvaluationTypeUseCase, DeleteEvaluationTypeCommand } from "@/scolar/application/useCases/evaluationTypes/deleteEvaluationTypeUseCase";
+import { EVALUATION_TYPE_DELETE_USECASE } from "@/scolar/domain/symbols/EvaluationTypeSymbol";
+
+interface Props {
+    evaluationType: EvaluationType;
+    onConfirm: () => void;
+}
+
+export const EvaluationTypeDeleteContainer = ({ evaluationType, onConfirm }: Props) => {
+    const deleteEvalType = useInjection<DeleteEvaluationTypeUseCase>(EVALUATION_TYPE_DELETE_USECASE);
+
+    const handleDelete = async () => {
+        const res = await deleteEvalType.execute(new DeleteEvaluationTypeCommand(evaluationType.id));
+        if (res.isLeft()) {
+            toast({
+                title: 'Error eliminando',
+                description: 'No se pudo eliminar el tipo de evaluación',
+                variant: 'destructive'
+            });
+            return;
+        }
+        toast({
+            title: 'Tipo de evaluación eliminado',
+            description: 'El tipo de evaluación se eliminó correctamente',
+            variant: 'success'
+        });
+        onConfirm();
+    };
+
+    return <EvaluationTypeDeletePresenter evaluationType={evaluationType} onConfirm={handleDelete} />;
+};
+

--- a/src/scolar/presentation/ui/EvaluationType/Delete/EvaluationTypeDeletePresenter.tsx
+++ b/src/scolar/presentation/ui/EvaluationType/Delete/EvaluationTypeDeletePresenter.tsx
@@ -1,0 +1,36 @@
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { EvaluationType } from "@/scolar/domain/entities/evaluation_type";
+import { Trash } from "lucide-react";
+
+interface Props {
+    evaluationType: EvaluationType;
+    onConfirm: () => void;
+}
+
+export const EvaluationTypeDeletePresenter = ({ evaluationType, onConfirm }: Props) => {
+    return (
+        <Dialog>
+            <DialogTrigger asChild>
+                <button title="Eliminar" type="button" className="p-1 rounded-full hover:bg-primary-500 transition">
+                    <Trash className="w-5 h-5 text-primary-200 hover:text-white" />
+                </button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle>¿Eliminar tipo de evaluación?</DialogTitle>
+                    <DialogDescription>
+                        <>Esta acción no se puede deshacer.<br />Tipo: <strong>{evaluationType.name}</strong></>
+                    </DialogDescription>
+                </DialogHeader>
+                <DialogFooter className="sm:justify-start">
+                    <DialogClose asChild>
+                        <Button type="button" variant="destructive" onClick={onConfirm}>Confirmar</Button>
+                    </DialogClose>
+                    <Button type="button" variant="outline">Cancelar</Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};
+

--- a/src/scolar/presentation/ui/EvaluationType/Edit/EvaluationTypeEditContainer.tsx
+++ b/src/scolar/presentation/ui/EvaluationType/Edit/EvaluationTypeEditContainer.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useTransition } from "react";
+import { useForm } from "react-hook-form";
+import { useInjection } from "inversify-react";
+import { useNavigate, useParams } from "react-router-dom";
+import { toast } from "@/hooks/use-toast";
+import { EvaluationTypeEditPresenter } from "./EvaluationTypeEditPresenter";
+import { GetEvaluationTypeUseCase, GetEvaluationTypeCommand } from "@/scolar/application/useCases/evaluationTypes/getEvaluationTypeUseCase";
+import { UpdateEvaluationTypeUseCase, UpdateEvaluationTypeCommand } from "@/scolar/application/useCases/evaluationTypes/updateEvaluationTypeUseCase";
+import { EVALUATION_TYPE_GET_USECASE, EVALUATION_TYPE_UPDATE_USECASE } from "@/scolar/domain/symbols/EvaluationTypeSymbol";
+
+interface FormValues {
+    data: {
+        name: string;
+        description: string;
+        weight: string;
+    }
+}
+
+export const EvaluationTypeEditContainer = () => {
+    const { id } = useParams();
+    const navigate = useNavigate();
+    const [isPending, startTransition] = useTransition();
+    const getEvalType = useInjection<GetEvaluationTypeUseCase>(EVALUATION_TYPE_GET_USECASE);
+    const updateEvalType = useInjection<UpdateEvaluationTypeUseCase>(EVALUATION_TYPE_UPDATE_USECASE);
+
+    const { register, handleSubmit, formState: { errors }, reset, watch } = useForm<FormValues>({
+        defaultValues: { data: { name: '', description: '', weight: '' } }
+    });
+
+    const formData = watch('data');
+
+    useEffect(() => {
+        if (!id) return;
+        startTransition(async () => {
+            const res = await getEvalType.execute(new GetEvaluationTypeCommand(Number(id)));
+            if (res.isLeft()) {
+                toast({ title: 'Error', description: 'No se pudo cargar', variant: 'destructive' });
+                navigate('/tipos-evaluacion');
+                return;
+            }
+            const data = res.extract();
+            if (data) {
+                reset({ data: { name: data.name, description: data.description, weight: data.weight } });
+            }
+        });
+    }, [id]);
+
+    const onSubmit = (values: FormValues) => {
+        if (!id) return;
+        startTransition(async () => {
+            const command = new UpdateEvaluationTypeCommand(Number(id), values.data.name, values.data.description, values.data.weight);
+            const res = await updateEvalType.execute(command);
+            if (res.isLeft()) {
+                const fail = res.extract();
+                toast({ title: 'Error', description: fail.map(f => f.getMessage()).join(', '), variant: 'destructive' });
+                return;
+            }
+            toast({ title: 'Tipo de evaluación actualizado', description: 'Cambios guardados', variant: 'success' });
+            navigate('/tipos-evaluacion');
+        });
+    };
+
+    const onCancel = () => navigate('/tipos-evaluacion');
+
+    return (
+        <EvaluationTypeEditPresenter
+            onSubmit={handleSubmit(onSubmit)}
+            register={register}
+            errors={errors}
+            isSubmitting={isPending}
+            onCancel={onCancel}
+            formData={formData}
+        />
+    );
+};
+

--- a/src/scolar/presentation/ui/EvaluationType/Edit/EvaluationTypeEditPresenter.tsx
+++ b/src/scolar/presentation/ui/EvaluationType/Edit/EvaluationTypeEditPresenter.tsx
@@ -1,0 +1,57 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+
+interface FormValues {
+    data: {
+        name: string;
+        description: string;
+        weight: string;
+    }
+}
+
+interface Props {
+    onSubmit: () => void;
+    onCancel: () => void;
+    register: UseFormRegister<FormValues>;
+    errors: FieldErrors<FormValues>;
+    isSubmitting: boolean;
+    formData: FormValues['data'];
+}
+
+export const EvaluationTypeEditPresenter = ({ onSubmit, onCancel, register, errors, isSubmitting }: Props) => {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Editar Tipo de Evaluación</CardTitle>
+            </CardHeader>
+            <form onSubmit={onSubmit}>
+                <CardContent className="space-y-4">
+                    <div className="space-y-2">
+                        <Label htmlFor="name">Nombre</Label>
+                        <Input id="name" {...register('data.name', { required: true })} />
+                        {errors.data?.name && (<span className="text-red-500 text-sm">{errors.data.name.message}</span>)}
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="description">Descripción</Label>
+                        <Textarea id="description" {...register('data.description', { required: true })} />
+                        {errors.data?.description && (<span className="text-red-500 text-sm">{errors.data.description.message}</span>)}
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="weight">Peso</Label>
+                        <Input id="weight" {...register('data.weight', { required: true })} />
+                        {errors.data?.weight && (<span className="text-red-500 text-sm">{errors.data.weight.message}</span>)}
+                    </div>
+                </CardContent>
+                <CardFooter className="flex justify-between">
+                    <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>Cancelar</Button>
+                    <Button type="submit" disabled={isSubmitting}>{isSubmitting ? 'Guardando...' : 'Guardar'}</Button>
+                </CardFooter>
+            </form>
+        </Card>
+    );
+};
+

--- a/src/scolar/presentation/ui/EvaluationType/List/EvaluationTypeListContainer.tsx
+++ b/src/scolar/presentation/ui/EvaluationType/List/EvaluationTypeListContainer.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState, useTransition, useRef } from "react";
+import { useInjection } from "inversify-react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "@/hooks/use-toast";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { EvaluationType } from "@/scolar/domain/entities/evaluation_type";
+import { ListEvaluationTypeUseCase, ListEvaluationTypeCommand } from "@/scolar/application/useCases/evaluationTypes/listEvaluationTypeUseCase";
+import { EVALUATION_TYPE_LIST_USECASE } from "@/scolar/domain/symbols/EvaluationTypeSymbol";
+import { EvaluationTypeListPresenter } from "./EvaluationTypeListPresenter";
+
+export const EvaluationTypeListContainer = () => {
+    const listEvalTypes = useInjection<ListEvaluationTypeUseCase>(EVALUATION_TYPE_LIST_USECASE);
+    const [isPending, startTransition] = useTransition();
+    const [command, setCommand] = useState({ page: 1, perPage: 10, where: '', orderBy: [] as string[] });
+    const [result, setResult] = useState<PaginatedResult<EvaluationType>>({
+        data: [],
+        meta: { currentPage: 1, lastPage: 1, next: null, perPage: 10, prev: null, total: 0 }
+    });
+    const debounceRef = useRef<NodeJS.Timeout | null>(null);
+    const navigate = useNavigate();
+
+    const loadData = async () => {
+        startTransition(async () => {
+            const res = await listEvalTypes.execute(new ListEvaluationTypeCommand(command.page, command.perPage, command.orderBy, command.where));
+            if (res.isLeft()) {
+                toast({ title: 'Error', description: 'No se pudo cargar', variant: 'destructive' });
+                return;
+            }
+            setResult(res.extract() as PaginatedResult<EvaluationType>);
+        });
+    };
+
+    useEffect(() => { loadData(); }, [command]);
+
+    const handleAdd = () => navigate('/tipos-evaluacion/nuevo');
+    const handleEdit = (et: EvaluationType) => navigate(`/tipos-evaluacion/${et.id}`);
+
+    const handlePaginate = (page: number) => setCommand({ ...command, page });
+
+    const handleSearch = (term: string) => {
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        debounceRef.current = setTimeout(() => setCommand({ ...command, where: term }), 300);
+    };
+
+    const handleDeleted = () => loadData();
+
+    return (
+        <EvaluationTypeListPresenter
+            evaluationTypes={result}
+            onAdd={handleAdd}
+            onEdit={handleEdit}
+            onDeleted={handleDeleted}
+            isPending={isPending}
+            onPaginate={handlePaginate}
+            onSearch={handleSearch}
+        />
+    );
+};
+

--- a/src/scolar/presentation/ui/EvaluationType/List/EvaluationTypeListPresenter.tsx
+++ b/src/scolar/presentation/ui/EvaluationType/List/EvaluationTypeListPresenter.tsx
@@ -1,0 +1,91 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Pagination, PaginationContent, PaginationItem, PaginationLink, PaginationNext, PaginationPrevious } from "@/components/ui/pagination";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Input } from "@/components/ui/input";
+import { Search, Edit, Plus } from "lucide-react";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { EvaluationType } from "@/scolar/domain/entities/evaluation_type";
+import { EvaluationTypeDeleteContainer } from "../Delete/EvaluationTypeDeleteContainer";
+
+interface Props {
+    evaluationTypes: PaginatedResult<EvaluationType>;
+    onAdd: () => void;
+    onEdit: (et: EvaluationType) => void;
+    onDeleted: () => void;
+    onPaginate: (page: number) => void;
+    onSearch: (term: string) => void;
+    isPending?: boolean;
+}
+
+export const EvaluationTypeListPresenter = ({ evaluationTypes, onAdd, onEdit, onDeleted, onPaginate, onSearch, isPending }: Props) => {
+    return (
+        <Card>
+            <CardHeader className="flex flex-row items-center justify-between">
+                <CardTitle>Tipos de Evaluación</CardTitle>
+                <Button onClick={onAdd} size="sm">
+                    <Plus className="h-4 w-4 mr-2" /> Nuevo
+                </Button>
+            </CardHeader>
+            <CardContent>
+                <div className="relative flex-1 mb-4">
+                    <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+                    <Input type="search" placeholder="Buscar..." className="pl-9" onChange={e => onSearch(e.target.value)} />
+                </div>
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead>Nombre</TableHead>
+                            <TableHead>Descripción</TableHead>
+                            <TableHead>Peso</TableHead>
+                            <TableHead className="text-right">Acciones</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {isPending && (
+                            <TableRow>
+                                <TableCell colSpan={4}><Skeleton className="h-4 w-full" /></TableCell>
+                            </TableRow>
+                        )}
+                        {evaluationTypes.data.map(et => (
+                            <TableRow key={et.id}>
+                                <TableCell className="font-medium">{et.name}</TableCell>
+                                <TableCell>{et.description}</TableCell>
+                                <TableCell>{et.weight}</TableCell>
+                                <TableCell className="text-right">
+                                    <div className="flex justify-end gap-2">
+                                        <Button variant="ghost" size="icon" onClick={() => onEdit(et)}>
+                                            <Edit className="h-4 w-4" />
+                                        </Button>
+                                        <EvaluationTypeDeleteContainer evaluationType={et} onConfirm={onDeleted} />
+                                    </div>
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+                <div className="mt-4 flex justify-end items-center gap-4">
+                    <Pagination>
+                        <PaginationContent>
+                            <PaginationItem>
+                                <PaginationPrevious href="#" className={evaluationTypes.meta.prev ? 'cursor-pointer' : 'cursor-not-allowed'} onClick={() => onPaginate(evaluationTypes.meta.currentPage - 1)} />
+                            </PaginationItem>
+                            {Array.from({ length: evaluationTypes.meta.lastPage }, (_, i) => i + 1).map(page => (
+                                <PaginationItem key={page}>
+                                    <PaginationLink href="#" isActive={page === evaluationTypes.meta.currentPage} onClick={() => onPaginate(page)}>
+                                        {page}
+                                    </PaginationLink>
+                                </PaginationItem>
+                            ))}
+                            <PaginationItem>
+                                <PaginationNext href="#" className={evaluationTypes.meta.next ? 'cursor-pointer' : 'cursor-not-allowed'} onClick={() => onPaginate(evaluationTypes.meta.currentPage + 1)} />
+                            </PaginationItem>
+                        </PaginationContent>
+                    </Pagination>
+                </div>
+            </CardContent>
+        </Card>
+    );
+};
+

--- a/src/scolar/presentation/ui/GradingSystem/Create/GradingSystemCreateContainer.tsx
+++ b/src/scolar/presentation/ui/GradingSystem/Create/GradingSystemCreateContainer.tsx
@@ -1,0 +1,55 @@
+import { useInjection } from "inversify-react";
+import { useNavigate } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { useTransition } from "react";
+import { toast } from "@/hooks/use-toast";
+import { GradingSystemCreatePresenter } from "./GradingSystemCreatePresenter";
+import { CreateGradingSystemUseCase, CreateGradingSystemCommand } from "@/scolar/application/useCases/gradingSystems/createGradingSystemUseCase";
+import { GRADING_SYSTEM_CREATE_USECASE } from "@/scolar/domain/symbols/GradingSystemSymbol";
+
+interface FormValues {
+    data: {
+        name: string;
+        description: string;
+        numberOfTerms: number;
+        passingScore: string;
+    }
+}
+
+export const GradingSystemCreateContainer = () => {
+    const navigate = useNavigate();
+    const [isPending, startTransition] = useTransition();
+    const createGS = useInjection<CreateGradingSystemUseCase>(GRADING_SYSTEM_CREATE_USECASE);
+    const { register, handleSubmit, formState: { errors }, watch } = useForm<FormValues>({
+        defaultValues: { data: { name: '', description: '', numberOfTerms: 1, passingScore: '' } }
+    });
+    const formData = watch('data');
+
+    const onSubmit = (values: FormValues) => {
+        startTransition(async () => {
+            const command = new CreateGradingSystemCommand(values.data.name, values.data.description, values.data.numberOfTerms, values.data.passingScore);
+            const res = await createGS.execute(command);
+            if (res.isLeft()) {
+                const fail = res.extract();
+                toast({ title: 'Error', description: fail.map(f => f.getMessage()).join(', '), variant: 'destructive' });
+                return;
+            }
+            toast({ title: 'Sistema de calificación creado', description: 'Se creó correctamente', variant: 'success' });
+            navigate('/sistemas-calificacion');
+        });
+    };
+
+    const onCancel = () => navigate('/sistemas-calificacion');
+
+    return (
+        <GradingSystemCreatePresenter
+            onSubmit={handleSubmit(onSubmit)}
+            register={register}
+            errors={errors}
+            isSubmitting={isPending}
+            onCancel={onCancel}
+            formData={formData}
+        />
+    );
+};
+

--- a/src/scolar/presentation/ui/GradingSystem/Create/GradingSystemCreatePresenter.tsx
+++ b/src/scolar/presentation/ui/GradingSystem/Create/GradingSystemCreatePresenter.tsx
@@ -1,0 +1,63 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+
+interface FormValues {
+    data: {
+        name: string;
+        description: string;
+        numberOfTerms: number;
+        passingScore: string;
+    }
+}
+
+interface Props {
+    onSubmit: () => void;
+    onCancel: () => void;
+    register: UseFormRegister<FormValues>;
+    errors: FieldErrors<FormValues>;
+    isSubmitting: boolean;
+    formData: FormValues['data'];
+}
+
+export const GradingSystemCreatePresenter = ({ onSubmit, onCancel, register, errors, isSubmitting }: Props) => {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Nuevo Sistema de Calificación</CardTitle>
+            </CardHeader>
+            <form onSubmit={onSubmit}>
+                <CardContent className="space-y-4">
+                    <div className="space-y-2">
+                        <Label htmlFor="name">Nombre</Label>
+                        <Input id="name" {...register('data.name', { required: true })} />
+                        {errors.data?.name && <span className="text-red-500 text-sm">{errors.data.name.message}</span>}
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="description">Descripción</Label>
+                        <Textarea id="description" {...register('data.description', { required: true })} />
+                        {errors.data?.description && <span className="text-red-500 text-sm">{errors.data.description.message}</span>}
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="numberOfTerms">Número de periodos</Label>
+                        <Input id="numberOfTerms" type="number" {...register('data.numberOfTerms', { required: true, valueAsNumber: true })} />
+                        {errors.data?.numberOfTerms && <span className="text-red-500 text-sm">{errors.data.numberOfTerms.message}</span>}
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="passingScore">Puntaje aprobatorio</Label>
+                        <Input id="passingScore" {...register('data.passingScore', { required: true })} />
+                        {errors.data?.passingScore && <span className="text-red-500 text-sm">{errors.data.passingScore.message}</span>}
+                    </div>
+                </CardContent>
+                <CardFooter className="flex justify-between">
+                    <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>Cancelar</Button>
+                    <Button type="submit" disabled={isSubmitting}>{isSubmitting ? 'Guardando...' : 'Guardar'}</Button>
+                </CardFooter>
+            </form>
+        </Card>
+    );
+};
+

--- a/src/scolar/presentation/ui/GradingSystem/Delete/GradingSystemDeleteContainer.tsx
+++ b/src/scolar/presentation/ui/GradingSystem/Delete/GradingSystemDeleteContainer.tsx
@@ -1,0 +1,28 @@
+import { useInjection } from "inversify-react";
+import { toast } from "@/hooks/use-toast";
+import { GradingSystem } from "@/scolar/domain/entities/grading_system";
+import { GradingSystemDeletePresenter } from "./GradingSystemDeletePresenter";
+import { DeleteGradingSystemUseCase, DeleteGradingSystemCommand } from "@/scolar/application/useCases/gradingSystems/deleteGradingSystemUseCase";
+import { GRADING_SYSTEM_DELETE_USECASE } from "@/scolar/domain/symbols/GradingSystemSymbol";
+
+interface Props {
+    gradingSystem: GradingSystem;
+    onConfirm: () => void;
+}
+
+export const GradingSystemDeleteContainer = ({ gradingSystem, onConfirm }: Props) => {
+    const deleteGS = useInjection<DeleteGradingSystemUseCase>(GRADING_SYSTEM_DELETE_USECASE);
+
+    const handleDelete = async () => {
+        const res = await deleteGS.execute(new DeleteGradingSystemCommand(gradingSystem.id));
+        if (res.isLeft()) {
+            toast({ title: 'Error eliminando', description: 'No se pudo eliminar', variant: 'destructive' });
+            return;
+        }
+        toast({ title: 'Sistema de calificación eliminado', description: 'Eliminado correctamente', variant: 'success' });
+        onConfirm();
+    };
+
+    return <GradingSystemDeletePresenter gradingSystem={gradingSystem} onConfirm={handleDelete} />;
+};
+

--- a/src/scolar/presentation/ui/GradingSystem/Delete/GradingSystemDeletePresenter.tsx
+++ b/src/scolar/presentation/ui/GradingSystem/Delete/GradingSystemDeletePresenter.tsx
@@ -1,0 +1,36 @@
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { GradingSystem } from "@/scolar/domain/entities/grading_system";
+import { Trash } from "lucide-react";
+
+interface Props {
+    gradingSystem: GradingSystem;
+    onConfirm: () => void;
+}
+
+export const GradingSystemDeletePresenter = ({ gradingSystem, onConfirm }: Props) => {
+    return (
+        <Dialog>
+            <DialogTrigger asChild>
+                <button title="Eliminar" type="button" className="p-1 rounded-full hover:bg-primary-500 transition">
+                    <Trash className="w-5 h-5 text-primary-200 hover:text-white" />
+                </button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle>¿Eliminar sistema de calificación?</DialogTitle>
+                    <DialogDescription>
+                        <>Esta acción no se puede deshacer.<br />Sistema: <strong>{gradingSystem.name}</strong></>
+                    </DialogDescription>
+                </DialogHeader>
+                <DialogFooter className="sm:justify-start">
+                    <DialogClose asChild>
+                        <Button type="button" variant="destructive" onClick={onConfirm}>Confirmar</Button>
+                    </DialogClose>
+                    <Button type="button" variant="outline">Cancelar</Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};
+

--- a/src/scolar/presentation/ui/GradingSystem/Edit/GradingSystemEditContainer.tsx
+++ b/src/scolar/presentation/ui/GradingSystem/Edit/GradingSystemEditContainer.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useTransition } from "react";
+import { useForm } from "react-hook-form";
+import { useInjection } from "inversify-react";
+import { useNavigate, useParams } from "react-router-dom";
+import { toast } from "@/hooks/use-toast";
+import { GradingSystemEditPresenter } from "./GradingSystemEditPresenter";
+import { GetGradingSystemUseCase, GetGradingSystemCommand } from "@/scolar/application/useCases/gradingSystems/getGradingSystemUseCase";
+import { UpdateGradingSystemUseCase, UpdateGradingSystemCommand } from "@/scolar/application/useCases/gradingSystems/updateGradingSystemUseCase";
+import { GRADING_SYSTEM_GET_USECASE, GRADING_SYSTEM_UPDATE_USECASE } from "@/scolar/domain/symbols/GradingSystemSymbol";
+
+interface FormValues {
+    data: {
+        name: string;
+        description: string;
+        numberOfTerms: number;
+        passingScore: string;
+    }
+}
+
+export const GradingSystemEditContainer = () => {
+    const { id } = useParams();
+    const navigate = useNavigate();
+    const [isPending, startTransition] = useTransition();
+    const getGS = useInjection<GetGradingSystemUseCase>(GRADING_SYSTEM_GET_USECASE);
+    const updateGS = useInjection<UpdateGradingSystemUseCase>(GRADING_SYSTEM_UPDATE_USECASE);
+
+    const { register, handleSubmit, formState: { errors }, reset, watch } = useForm<FormValues>({
+        defaultValues: { data: { name: '', description: '', numberOfTerms: 1, passingScore: '' } }
+    });
+
+    const formData = watch('data');
+
+    useEffect(() => {
+        if (!id) return;
+        startTransition(async () => {
+            const res = await getGS.execute(new GetGradingSystemCommand(Number(id)));
+            if (res.isLeft()) {
+                toast({ title: 'Error', description: 'No se pudo cargar', variant: 'destructive' });
+                navigate('/sistemas-calificacion');
+                return;
+            }
+            const data = res.extract();
+            if (data) {
+                reset({ data: { name: data.name, description: data.description, numberOfTerms: data.numberOfTerms, passingScore: data.passingScore } });
+            }
+        });
+    }, [id]);
+
+    const onSubmit = (values: FormValues) => {
+        if (!id) return;
+        startTransition(async () => {
+            const command = new UpdateGradingSystemCommand(Number(id), values.data.name, values.data.description, values.data.numberOfTerms, values.data.passingScore);
+            const res = await updateGS.execute(command);
+            if (res.isLeft()) {
+                const fail = res.extract();
+                toast({ title: 'Error', description: fail.map(f => f.getMessage()).join(', '), variant: 'destructive' });
+                return;
+            }
+            toast({ title: 'Sistema de calificación actualizado', description: 'Cambios guardados', variant: 'success' });
+            navigate('/sistemas-calificacion');
+        });
+    };
+
+    const onCancel = () => navigate('/sistemas-calificacion');
+
+    return (
+        <GradingSystemEditPresenter
+            onSubmit={handleSubmit(onSubmit)}
+            register={register}
+            errors={errors}
+            isSubmitting={isPending}
+            onCancel={onCancel}
+            formData={formData}
+        />
+    );
+};
+

--- a/src/scolar/presentation/ui/GradingSystem/Edit/GradingSystemEditPresenter.tsx
+++ b/src/scolar/presentation/ui/GradingSystem/Edit/GradingSystemEditPresenter.tsx
@@ -1,0 +1,63 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+
+interface FormValues {
+    data: {
+        name: string;
+        description: string;
+        numberOfTerms: number;
+        passingScore: string;
+    }
+}
+
+interface Props {
+    onSubmit: () => void;
+    onCancel: () => void;
+    register: UseFormRegister<FormValues>;
+    errors: FieldErrors<FormValues>;
+    isSubmitting: boolean;
+    formData: FormValues['data'];
+}
+
+export const GradingSystemEditPresenter = ({ onSubmit, onCancel, register, errors, isSubmitting }: Props) => {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Editar Sistema de Calificación</CardTitle>
+            </CardHeader>
+            <form onSubmit={onSubmit}>
+                <CardContent className="space-y-4">
+                    <div className="space-y-2">
+                        <Label htmlFor="name">Nombre</Label>
+                        <Input id="name" {...register('data.name', { required: true })} />
+                        {errors.data?.name && <span className="text-red-500 text-sm">{errors.data.name.message}</span>}
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="description">Descripción</Label>
+                        <Textarea id="description" {...register('data.description', { required: true })} />
+                        {errors.data?.description && <span className="text-red-500 text-sm">{errors.data.description.message}</span>}
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="numberOfTerms">Número de periodos</Label>
+                        <Input id="numberOfTerms" type="number" {...register('data.numberOfTerms', { required: true, valueAsNumber: true })} />
+                        {errors.data?.numberOfTerms && <span className="text-red-500 text-sm">{errors.data.numberOfTerms.message}</span>}
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="passingScore">Puntaje aprobatorio</Label>
+                        <Input id="passingScore" {...register('data.passingScore', { required: true })} />
+                        {errors.data?.passingScore && <span className="text-red-500 text-sm">{errors.data.passingScore.message}</span>}
+                    </div>
+                </CardContent>
+                <CardFooter className="flex justify-between">
+                    <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>Cancelar</Button>
+                    <Button type="submit" disabled={isSubmitting}>{isSubmitting ? 'Guardando...' : 'Guardar'}</Button>
+                </CardFooter>
+            </form>
+        </Card>
+    );
+};
+

--- a/src/scolar/presentation/ui/GradingSystem/List/GradingSystemListContainer.tsx
+++ b/src/scolar/presentation/ui/GradingSystem/List/GradingSystemListContainer.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useRef, useState, useTransition } from "react";
+import { useInjection } from "inversify-react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "@/hooks/use-toast";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { GradingSystem } from "@/scolar/domain/entities/grading_system";
+import { ListGradingSystemUseCase, ListGradingSystemCommand } from "@/scolar/application/useCases/gradingSystems/listGradingSystemUseCase";
+import { GRADING_SYSTEM_LIST_USECASE } from "@/scolar/domain/symbols/GradingSystemSymbol";
+import { GradingSystemListPresenter } from "./GradingSystemListPresenter";
+
+export const GradingSystemListContainer = () => {
+    const listGS = useInjection<ListGradingSystemUseCase>(GRADING_SYSTEM_LIST_USECASE);
+    const [isPending, startTransition] = useTransition();
+    const [command, setCommand] = useState({ page: 1, perPage: 10, where: '', orderBy: [] as string[] });
+    const [result, setResult] = useState<PaginatedResult<GradingSystem>>({
+        data: [],
+        meta: { currentPage: 1, lastPage: 1, next: null, perPage: 10, prev: null, total: 0 }
+    });
+    const debounceRef = useRef<NodeJS.Timeout | null>(null);
+    const navigate = useNavigate();
+
+    const loadData = async () => {
+        startTransition(async () => {
+            const res = await listGS.execute(new ListGradingSystemCommand(command.page, command.perPage, command.orderBy, command.where));
+            if (res.isLeft()) {
+                toast({ title: 'Error', description: 'No se pudo cargar', variant: 'destructive' });
+                return;
+            }
+            setResult(res.extract() as PaginatedResult<GradingSystem>);
+        });
+    };
+
+    useEffect(() => { loadData(); }, [command]);
+
+    const handleAdd = () => navigate('/sistemas-calificacion/nuevo');
+    const handleEdit = (gs: GradingSystem) => navigate(`/sistemas-calificacion/${gs.id}`);
+    const handlePaginate = (page: number) => setCommand({ ...command, page });
+    const handleSearch = (term: string) => {
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        debounceRef.current = setTimeout(() => setCommand({ ...command, where: term }), 300);
+    };
+    const handleDeleted = () => loadData();
+
+    return (
+        <GradingSystemListPresenter
+            gradingSystems={result}
+            onAdd={handleAdd}
+            onEdit={handleEdit}
+            onDeleted={handleDeleted}
+            onPaginate={handlePaginate}
+            onSearch={handleSearch}
+            isPending={isPending}
+        />
+    );
+};
+

--- a/src/scolar/presentation/ui/GradingSystem/List/GradingSystemListPresenter.tsx
+++ b/src/scolar/presentation/ui/GradingSystem/List/GradingSystemListPresenter.tsx
@@ -1,0 +1,91 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Pagination, PaginationContent, PaginationItem, PaginationLink, PaginationNext, PaginationPrevious } from "@/components/ui/pagination";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Input } from "@/components/ui/input";
+import { Search, Edit, Plus } from "lucide-react";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { GradingSystem } from "@/scolar/domain/entities/grading_system";
+import { GradingSystemDeleteContainer } from "../Delete/GradingSystemDeleteContainer";
+
+interface Props {
+    gradingSystems: PaginatedResult<GradingSystem>;
+    onAdd: () => void;
+    onEdit: (gs: GradingSystem) => void;
+    onDeleted: () => void;
+    onPaginate: (page: number) => void;
+    onSearch: (term: string) => void;
+    isPending?: boolean;
+}
+
+export const GradingSystemListPresenter = ({ gradingSystems, onAdd, onEdit, onDeleted, onPaginate, onSearch, isPending }: Props) => {
+    return (
+        <Card>
+            <CardHeader className="flex flex-row items-center justify-between">
+                <CardTitle>Sistemas de Calificación</CardTitle>
+                <Button onClick={onAdd} size="sm"><Plus className="h-4 w-4 mr-2" /> Nuevo</Button>
+            </CardHeader>
+            <CardContent>
+                <div className="relative flex-1 mb-4">
+                    <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+                    <Input type="search" placeholder="Buscar..." className="pl-9" onChange={e => onSearch(e.target.value)} />
+                </div>
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead>Nombre</TableHead>
+                            <TableHead>Descripción</TableHead>
+                            <TableHead># Periodos</TableHead>
+                            <TableHead>Puntaje</TableHead>
+                            <TableHead className="text-right">Acciones</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {isPending && (
+                            <TableRow>
+                                <TableCell colSpan={5}><Skeleton className="h-4 w-full" /></TableCell>
+                            </TableRow>
+                        )}
+                        {gradingSystems.data.map(gs => (
+                            <TableRow key={gs.id}>
+                                <TableCell className="font-medium">{gs.name}</TableCell>
+                                <TableCell>{gs.description}</TableCell>
+                                <TableCell>{gs.numberOfTerms}</TableCell>
+                                <TableCell>{gs.passingScore}</TableCell>
+                                <TableCell className="text-right">
+                                    <div className="flex justify-end gap-2">
+                                        <Button variant="ghost" size="icon" onClick={() => onEdit(gs)}>
+                                            <Edit className="h-4 w-4" />
+                                        </Button>
+                                        <GradingSystemDeleteContainer gradingSystem={gs} onConfirm={onDeleted} />
+                                    </div>
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+                <div className="mt-4 flex justify-end items-center gap-4">
+                    <Pagination>
+                        <PaginationContent>
+                            <PaginationItem>
+                                <PaginationPrevious href="#" className={gradingSystems.meta.prev ? 'cursor-pointer' : 'cursor-not-allowed'} onClick={() => onPaginate(gradingSystems.meta.currentPage - 1)} />
+                            </PaginationItem>
+                            {Array.from({ length: gradingSystems.meta.lastPage }, (_, i) => i + 1).map(page => (
+                                <PaginationItem key={page}>
+                                    <PaginationLink href="#" isActive={page === gradingSystems.meta.currentPage} onClick={() => onPaginate(page)}>
+                                        {page}
+                                    </PaginationLink>
+                                </PaginationItem>
+                            ))}
+                            <PaginationItem>
+                                <PaginationNext href="#" className={gradingSystems.meta.next ? 'cursor-pointer' : 'cursor-not-allowed'} onClick={() => onPaginate(gradingSystems.meta.currentPage + 1)} />
+                            </PaginationItem>
+                        </PaginationContent>
+                    </Pagination>
+                </div>
+            </CardContent>
+        </Card>
+    );
+};
+

--- a/src/scolar/presentation/ui/GradingTerm/Create/GradingTermCreateContainer.tsx
+++ b/src/scolar/presentation/ui/GradingTerm/Create/GradingTermCreateContainer.tsx
@@ -1,0 +1,56 @@
+import { useInjection } from "inversify-react";
+import { useNavigate } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { useTransition } from "react";
+import { toast } from "@/hooks/use-toast";
+import { GradingTermCreatePresenter } from "./GradingTermCreatePresenter";
+import { CreateGradingTermUseCase, CreateGradingTermCommand } from "@/scolar/application/useCases/gradingTerms/createGradingTermUseCase";
+import { GRADING_TERM_CREATE_USECASE } from "@/scolar/domain/symbols/GradingTermSymbol";
+
+interface FormValues {
+    data: {
+        gradingSystem_id: number;
+        academicYear_id: number;
+        name: string;
+        order: number;
+        weight: string;
+    }
+}
+
+export const GradingTermCreateContainer = () => {
+    const navigate = useNavigate();
+    const [isPending, startTransition] = useTransition();
+    const createGT = useInjection<CreateGradingTermUseCase>(GRADING_TERM_CREATE_USECASE);
+    const { register, handleSubmit, formState: { errors }, watch } = useForm<FormValues>({
+        defaultValues: { data: { gradingSystem_id: 0, academicYear_id: 0, name: '', order: 1, weight: '' } }
+    });
+    const formData = watch('data');
+
+    const onSubmit = (values: FormValues) => {
+        startTransition(async () => {
+            const c = new CreateGradingTermCommand(values.data.gradingSystem_id, values.data.academicYear_id, values.data.name, values.data.order, values.data.weight);
+            const res = await createGT.execute(c);
+            if (res.isLeft()) {
+                const fail = res.extract();
+                toast({ title: 'Error', description: fail.map(f => f.getMessage()).join(', '), variant: 'destructive' });
+                return;
+            }
+            toast({ title: 'Período de calificación creado', description: 'Creado correctamente', variant: 'success' });
+            navigate('/terminos-calificacion');
+        });
+    };
+
+    const onCancel = () => navigate('/terminos-calificacion');
+
+    return (
+        <GradingTermCreatePresenter
+            onSubmit={handleSubmit(onSubmit)}
+            register={register}
+            errors={errors}
+            isSubmitting={isPending}
+            onCancel={onCancel}
+            formData={formData}
+        />
+    );
+};
+

--- a/src/scolar/presentation/ui/GradingTerm/Create/GradingTermCreatePresenter.tsx
+++ b/src/scolar/presentation/ui/GradingTerm/Create/GradingTermCreatePresenter.tsx
@@ -1,0 +1,69 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+
+interface FormValues {
+    data: {
+        gradingSystem_id: number;
+        academicYear_id: number;
+        name: string;
+        order: number;
+        weight: string;
+    }
+}
+
+interface Props {
+    onSubmit: () => void;
+    onCancel: () => void;
+    register: UseFormRegister<FormValues>;
+    errors: FieldErrors<FormValues>;
+    isSubmitting: boolean;
+    formData: FormValues['data'];
+}
+
+export const GradingTermCreatePresenter = ({ onSubmit, onCancel, register, errors, isSubmitting }: Props) => {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Nuevo Período de Calificación</CardTitle>
+            </CardHeader>
+            <form onSubmit={onSubmit}>
+                <CardContent className="space-y-4">
+                    <div className="space-y-2">
+                        <Label htmlFor="gradingSystem_id">ID Sistema</Label>
+                        <Input id="gradingSystem_id" type="number" {...register('data.gradingSystem_id', { required: true, valueAsNumber: true })} />
+                        {errors.data?.gradingSystem_id && <span className="text-red-500 text-sm">{errors.data.gradingSystem_id.message}</span>}
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="academicYear_id">ID Año Académico</Label>
+                        <Input id="academicYear_id" type="number" {...register('data.academicYear_id', { required: true, valueAsNumber: true })} />
+                        {errors.data?.academicYear_id && <span className="text-red-500 text-sm">{errors.data.academicYear_id.message}</span>}
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="name">Nombre</Label>
+                        <Input id="name" {...register('data.name', { required: true })} />
+                        {errors.data?.name && <span className="text-red-500 text-sm">{errors.data.name.message}</span>}
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="order">Orden</Label>
+                        <Input id="order" type="number" {...register('data.order', { required: true, valueAsNumber: true })} />
+                        {errors.data?.order && <span className="text-red-500 text-sm">{errors.data.order.message}</span>}
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="weight">Peso</Label>
+                        <Input id="weight" {...register('data.weight', { required: true })} />
+                        {errors.data?.weight && <span className="text-red-500 text-sm">{errors.data.weight.message}</span>}
+                    </div>
+                </CardContent>
+                <CardFooter className="flex justify-between">
+                    <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>Cancelar</Button>
+                    <Button type="submit" disabled={isSubmitting}>{isSubmitting ? 'Guardando...' : 'Guardar'}</Button>
+                </CardFooter>
+            </form>
+        </Card>
+    );
+};
+

--- a/src/scolar/presentation/ui/GradingTerm/Delete/GradingTermDeleteContainer.tsx
+++ b/src/scolar/presentation/ui/GradingTerm/Delete/GradingTermDeleteContainer.tsx
@@ -1,0 +1,28 @@
+import { useInjection } from "inversify-react";
+import { toast } from "@/hooks/use-toast";
+import { GradingTerm } from "@/scolar/domain/entities/grading_term";
+import { GradingTermDeletePresenter } from "./GradingTermDeletePresenter";
+import { DeleteGradingTermUseCase, DeleteGradingTermCommand } from "@/scolar/application/useCases/gradingTerms/deleteGradingTermUseCase";
+import { GRADING_TERM_DELETE_USECASE } from "@/scolar/domain/symbols/GradingTermSymbol";
+
+interface Props {
+    gradingTerm: GradingTerm;
+    onConfirm: () => void;
+}
+
+export const GradingTermDeleteContainer = ({ gradingTerm, onConfirm }: Props) => {
+    const deleteGT = useInjection<DeleteGradingTermUseCase>(GRADING_TERM_DELETE_USECASE);
+
+    const handleDelete = async () => {
+        const res = await deleteGT.execute(new DeleteGradingTermCommand(gradingTerm.id));
+        if (res.isLeft()) {
+            toast({ title: 'Error eliminando', description: 'No se pudo eliminar', variant: 'destructive' });
+            return;
+        }
+        toast({ title: 'Período eliminado', description: 'Eliminado correctamente', variant: 'success' });
+        onConfirm();
+    };
+
+    return <GradingTermDeletePresenter gradingTerm={gradingTerm} onConfirm={handleDelete} />;
+};
+

--- a/src/scolar/presentation/ui/GradingTerm/Delete/GradingTermDeletePresenter.tsx
+++ b/src/scolar/presentation/ui/GradingTerm/Delete/GradingTermDeletePresenter.tsx
@@ -1,0 +1,36 @@
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { GradingTerm } from "@/scolar/domain/entities/grading_term";
+import { Trash } from "lucide-react";
+
+interface Props {
+    gradingTerm: GradingTerm;
+    onConfirm: () => void;
+}
+
+export const GradingTermDeletePresenter = ({ gradingTerm, onConfirm }: Props) => {
+    return (
+        <Dialog>
+            <DialogTrigger asChild>
+                <button title="Eliminar" type="button" className="p-1 rounded-full hover:bg-primary-500 transition">
+                    <Trash className="w-5 h-5 text-primary-200 hover:text-white" />
+                </button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle>¿Eliminar período?</DialogTitle>
+                    <DialogDescription>
+                        <>Esta acción no se puede deshacer.<br />Período: <strong>{gradingTerm.name}</strong></>
+                    </DialogDescription>
+                </DialogHeader>
+                <DialogFooter className="sm:justify-start">
+                    <DialogClose asChild>
+                        <Button type="button" variant="destructive" onClick={onConfirm}>Confirmar</Button>
+                    </DialogClose>
+                    <Button type="button" variant="outline">Cancelar</Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};
+

--- a/src/scolar/presentation/ui/GradingTerm/Edit/GradingTermEditContainer.tsx
+++ b/src/scolar/presentation/ui/GradingTerm/Edit/GradingTermEditContainer.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useTransition } from "react";
+import { useForm } from "react-hook-form";
+import { useInjection } from "inversify-react";
+import { useNavigate, useParams } from "react-router-dom";
+import { toast } from "@/hooks/use-toast";
+import { GradingTermEditPresenter } from "./GradingTermEditPresenter";
+import { GetGradingTermUseCase, GetGradingTermCommand } from "@/scolar/application/useCases/gradingTerms/getGradingTermUseCase";
+import { UpdateGradingTermUseCase, UpdateGradingTermCommand } from "@/scolar/application/useCases/gradingTerms/updateGradingTermUseCase";
+import { GRADING_TERM_GET_USECASE, GRADING_TERM_UPDATE_USECASE } from "@/scolar/domain/symbols/GradingTermSymbol";
+
+interface FormValues {
+    data: {
+        gradingSystem_id: number;
+        academicYear_id: number;
+        name: string;
+        order: number;
+        weight: string;
+    }
+}
+
+export const GradingTermEditContainer = () => {
+    const { id } = useParams();
+    const navigate = useNavigate();
+    const [isPending, startTransition] = useTransition();
+    const getGT = useInjection<GetGradingTermUseCase>(GRADING_TERM_GET_USECASE);
+    const updateGT = useInjection<UpdateGradingTermUseCase>(GRADING_TERM_UPDATE_USECASE);
+
+    const { register, handleSubmit, formState: { errors }, reset, watch } = useForm<FormValues>({
+        defaultValues: { data: { gradingSystem_id: 0, academicYear_id: 0, name: '', order: 1, weight: '' } }
+    });
+
+    const formData = watch('data');
+
+    useEffect(() => {
+        if (!id) return;
+        startTransition(async () => {
+            const res = await getGT.execute(new GetGradingTermCommand(Number(id)));
+            if (res.isLeft()) {
+                toast({ title: 'Error', description: 'No se pudo cargar', variant: 'destructive' });
+                navigate('/terminos-calificacion');
+                return;
+            }
+            const data = res.extract();
+            if (data) {
+                reset({ data: { gradingSystem_id: data.gradingSystem_id, academicYear_id: data.academicYear_id, name: data.name, order: data.order, weight: data.weight } });
+            }
+        });
+    }, [id]);
+
+    const onSubmit = (values: FormValues) => {
+        if (!id) return;
+        startTransition(async () => {
+            const command = new UpdateGradingTermCommand(Number(id), values.data.gradingSystem_id, values.data.academicYear_id, values.data.name, values.data.order, values.data.weight);
+            const res = await updateGT.execute(command);
+            if (res.isLeft()) {
+                const fail = res.extract();
+                toast({ title: 'Error', description: fail.map(f => f.getMessage()).join(', '), variant: 'destructive' });
+                return;
+            }
+            toast({ title: 'Período actualizado', description: 'Cambios guardados', variant: 'success' });
+            navigate('/terminos-calificacion');
+        });
+    };
+
+    const onCancel = () => navigate('/terminos-calificacion');
+
+    return (
+        <GradingTermEditPresenter
+            onSubmit={handleSubmit(onSubmit)}
+            register={register}
+            errors={errors}
+            isSubmitting={isPending}
+            onCancel={onCancel}
+            formData={formData}
+        />
+    );
+};
+

--- a/src/scolar/presentation/ui/GradingTerm/Edit/GradingTermEditPresenter.tsx
+++ b/src/scolar/presentation/ui/GradingTerm/Edit/GradingTermEditPresenter.tsx
@@ -1,0 +1,68 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+
+interface FormValues {
+    data: {
+        gradingSystem_id: number;
+        academicYear_id: number;
+        name: string;
+        order: number;
+        weight: string;
+    }
+}
+
+interface Props {
+    onSubmit: () => void;
+    onCancel: () => void;
+    register: UseFormRegister<FormValues>;
+    errors: FieldErrors<FormValues>;
+    isSubmitting: boolean;
+    formData: FormValues['data'];
+}
+
+export const GradingTermEditPresenter = ({ onSubmit, onCancel, register, errors, isSubmitting }: Props) => {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Editar Período de Calificación</CardTitle>
+            </CardHeader>
+            <form onSubmit={onSubmit}>
+                <CardContent className="space-y-4">
+                    <div className="space-y-2">
+                        <Label htmlFor="gradingSystem_id">ID Sistema</Label>
+                        <Input id="gradingSystem_id" type="number" {...register('data.gradingSystem_id', { required: true, valueAsNumber: true })} />
+                        {errors.data?.gradingSystem_id && <span className="text-red-500 text-sm">{errors.data.gradingSystem_id.message}</span>}
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="academicYear_id">ID Año Académico</Label>
+                        <Input id="academicYear_id" type="number" {...register('data.academicYear_id', { required: true, valueAsNumber: true })} />
+                        {errors.data?.academicYear_id && <span className="text-red-500 text-sm">{errors.data.academicYear_id.message}</span>}
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="name">Nombre</Label>
+                        <Input id="name" {...register('data.name', { required: true })} />
+                        {errors.data?.name && <span className="text-red-500 text-sm">{errors.data.name.message}</span>}
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="order">Orden</Label>
+                        <Input id="order" type="number" {...register('data.order', { required: true, valueAsNumber: true })} />
+                        {errors.data?.order && <span className="text-red-500 text-sm">{errors.data.order.message}</span>}
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="weight">Peso</Label>
+                        <Input id="weight" {...register('data.weight', { required: true })} />
+                        {errors.data?.weight && <span className="text-red-500 text-sm">{errors.data.weight.message}</span>}
+                    </div>
+                </CardContent>
+                <CardFooter className="flex justify-between">
+                    <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>Cancelar</Button>
+                    <Button type="submit" disabled={isSubmitting}>{isSubmitting ? 'Guardando...' : 'Guardar'}</Button>
+                </CardFooter>
+            </form>
+        </Card>
+    );
+};
+

--- a/src/scolar/presentation/ui/GradingTerm/List/GradingTermListContainer.tsx
+++ b/src/scolar/presentation/ui/GradingTerm/List/GradingTermListContainer.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useRef, useState, useTransition } from "react";
+import { useInjection } from "inversify-react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "@/hooks/use-toast";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { GradingTerm } from "@/scolar/domain/entities/grading_term";
+import { ListGradingTermUseCase, ListGradingTermCommand } from "@/scolar/application/useCases/gradingTerms/listGradingTermUseCase";
+import { GRADING_TERM_LIST_USECASE } from "@/scolar/domain/symbols/GradingTermSymbol";
+import { GradingTermListPresenter } from "./GradingTermListPresenter";
+
+export const GradingTermListContainer = () => {
+    const listGT = useInjection<ListGradingTermUseCase>(GRADING_TERM_LIST_USECASE);
+    const [isPending, startTransition] = useTransition();
+    const [command, setCommand] = useState({ page: 1, perPage: 10, where: '', orderBy: [] as string[] });
+    const [result, setResult] = useState<PaginatedResult<GradingTerm>>({
+        data: [],
+        meta: { currentPage: 1, lastPage: 1, next: null, perPage: 10, prev: null, total: 0 }
+    });
+    const debounceRef = useRef<NodeJS.Timeout | null>(null);
+    const navigate = useNavigate();
+
+    const loadData = async () => {
+        startTransition(async () => {
+            const res = await listGT.execute(new ListGradingTermCommand(command.page, command.perPage, command.orderBy, command.where));
+            if (res.isLeft()) {
+                toast({ title: 'Error', description: 'No se pudo cargar', variant: 'destructive' });
+                return;
+            }
+            setResult(res.extract() as PaginatedResult<GradingTerm>);
+        });
+    };
+
+    useEffect(() => { loadData(); }, [command]);
+
+    const handleAdd = () => navigate('/terminos-calificacion/nuevo');
+    const handleEdit = (gt: GradingTerm) => navigate(`/terminos-calificacion/${gt.id}`);
+    const handlePaginate = (page: number) => setCommand({ ...command, page });
+    const handleSearch = (term: string) => {
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        debounceRef.current = setTimeout(() => setCommand({ ...command, where: term }), 300);
+    };
+    const handleDeleted = () => loadData();
+
+    return (
+        <GradingTermListPresenter
+            gradingTerms={result}
+            onAdd={handleAdd}
+            onEdit={handleEdit}
+            onDeleted={handleDeleted}
+            onPaginate={handlePaginate}
+            onSearch={handleSearch}
+            isPending={isPending}
+        />
+    );
+};
+

--- a/src/scolar/presentation/ui/GradingTerm/List/GradingTermListPresenter.tsx
+++ b/src/scolar/presentation/ui/GradingTerm/List/GradingTermListPresenter.tsx
@@ -1,0 +1,87 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Pagination, PaginationContent, PaginationItem, PaginationLink, PaginationNext, PaginationPrevious } from "@/components/ui/pagination";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Input } from "@/components/ui/input";
+import { Search, Edit, Plus } from "lucide-react";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { GradingTerm } from "@/scolar/domain/entities/grading_term";
+import { GradingTermDeleteContainer } from "../Delete/GradingTermDeleteContainer";
+
+interface Props {
+    gradingTerms: PaginatedResult<GradingTerm>;
+    onAdd: () => void;
+    onEdit: (gt: GradingTerm) => void;
+    onDeleted: () => void;
+    onPaginate: (page: number) => void;
+    onSearch: (term: string) => void;
+    isPending?: boolean;
+}
+
+export const GradingTermListPresenter = ({ gradingTerms, onAdd, onEdit, onDeleted, onPaginate, onSearch, isPending }: Props) => {
+    return (
+        <Card>
+            <CardHeader className="flex flex-row items-center justify-between">
+                <CardTitle>Períodos de Calificación</CardTitle>
+                <Button onClick={onAdd} size="sm"><Plus className="h-4 w-4 mr-2" /> Nuevo</Button>
+            </CardHeader>
+            <CardContent>
+                <div className="relative flex-1 mb-4">
+                    <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+                    <Input type="search" placeholder="Buscar..." className="pl-9" onChange={e => onSearch(e.target.value)} />
+                </div>
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead>Nombre</TableHead>
+                            <TableHead>Orden</TableHead>
+                            <TableHead>Peso</TableHead>
+                            <TableHead className="text-right">Acciones</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {isPending && (
+                            <TableRow><TableCell colSpan={4}><Skeleton className="h-4 w-full" /></TableCell></TableRow>
+                        )}
+                        {gradingTerms.data.map(gt => (
+                            <TableRow key={gt.id}>
+                                <TableCell className="font-medium">{gt.name}</TableCell>
+                                <TableCell>{gt.order}</TableCell>
+                                <TableCell>{gt.weight}</TableCell>
+                                <TableCell className="text-right">
+                                    <div className="flex justify-end gap-2">
+                                        <Button variant="ghost" size="icon" onClick={() => onEdit(gt)}>
+                                            <Edit className="h-4 w-4" />
+                                        </Button>
+                                        <GradingTermDeleteContainer gradingTerm={gt} onConfirm={onDeleted} />
+                                    </div>
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+                <div className="mt-4 flex justify-end items-center gap-4">
+                    <Pagination>
+                        <PaginationContent>
+                            <PaginationItem>
+                                <PaginationPrevious href="#" className={gradingTerms.meta.prev ? 'cursor-pointer' : 'cursor-not-allowed'} onClick={() => onPaginate(gradingTerms.meta.currentPage - 1)} />
+                            </PaginationItem>
+                            {Array.from({ length: gradingTerms.meta.lastPage }, (_, i) => i + 1).map(page => (
+                                <PaginationItem key={page}>
+                                    <PaginationLink href="#" isActive={page === gradingTerms.meta.currentPage} onClick={() => onPaginate(page)}>
+                                        {page}
+                                    </PaginationLink>
+                                </PaginationItem>
+                            ))}
+                            <PaginationItem>
+                                <PaginationNext href="#" className={gradingTerms.meta.next ? 'cursor-pointer' : 'cursor-not-allowed'} onClick={() => onPaginate(gradingTerms.meta.currentPage + 1)} />
+                            </PaginationItem>
+                        </PaginationContent>
+                    </Pagination>
+                </div>
+            </CardContent>
+        </Card>
+    );
+};
+


### PR DESCRIPTION
## Summary
- implement list, get, update, and delete grading system use cases
- register grading system use cases in dependency injection container
- implement create, list, get, update, and delete grading term use cases
- wire grading term repository, service, and use cases into container

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 18 problems)


------
https://chatgpt.com/codex/tasks/task_e_68952ddb27dc8330b38d7dfca808516c