### PR TITLE
feat: add meeting, attendance, and behavior modules

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -22,6 +22,15 @@ import { GradingSystemEditContainer } from "./scolar/presentation/ui/GradingSyst
 import { GradingTermListContainer } from "./scolar/presentation/ui/GradingTerm/List/GradingTermListContainer";
 import { GradingTermCreateContainer } from "./scolar/presentation/ui/GradingTerm/Create/GradingTermCreateContainer";
 import { GradingTermEditContainer } from "./scolar/presentation/ui/GradingTerm/Edit/GradingTermEditContainer";
+import { MeetingTypeListContainer } from "./scolar/presentation/ui/MeetingType/List/MeetingTypeListContainer";
+import { MeetingTypeCreateContainer } from "./scolar/presentation/ui/MeetingType/Create/MeetingTypeCreateContainer";
+import { MeetingTypeEditContainer } from "./scolar/presentation/ui/MeetingType/Edit/MeetingTypeEditContainer";
+import { AttendanceCodeListContainer } from "./scolar/presentation/ui/AttendanceCode/List/AttendanceCodeListContainer";
+import { AttendanceCodeCreateContainer } from "./scolar/presentation/ui/AttendanceCode/Create/AttendanceCodeCreateContainer";
+import { AttendanceCodeEditContainer } from "./scolar/presentation/ui/AttendanceCode/Edit/AttendanceCodeEditContainer";
+import { BehaviorScaleListContainer } from "./scolar/presentation/ui/BehaviorScale/List/BehaviorScaleListContainer";
+import { BehaviorScaleCreateContainer } from "./scolar/presentation/ui/BehaviorScale/Create/BehaviorScaleCreateContainer";
+import { BehaviorScaleEditContainer } from "./scolar/presentation/ui/BehaviorScale/Edit/BehaviorScaleEditContainer";
 
 const isStandalone = !window.singleSpaNavigate;
 
@@ -33,7 +42,10 @@ export const MenuOptions = [
     { name: 'Periodos lectivos', path: '/periodos-lectivos' },
     { name: 'Sistemas de calificación', path: '/sistemas-calificacion' },
     { name: 'Períodos de calificación', path: '/terminos-calificacion' },
-    { name: 'Tipos de evaluación', path: '/tipos-evaluacion' }
+    { name: 'Tipos de evaluación', path: '/tipos-evaluacion' },
+    { name: 'Tipos de reunión', path: '/tipos-reuniones' },
+    { name: 'Códigos de asistencia', path: '/codigos-asistencia' },
+    { name: 'Escalas de comportamiento', path: '/escalas-comportamiento' }
 ];
 
 const router = createBrowserRouter([
@@ -60,6 +72,15 @@ const router = createBrowserRouter([
     { path: '/terminos-calificacion', Component: GradingTermListContainer },
     { path: '/terminos-calificacion/nuevo', Component: GradingTermCreateContainer },
     { path: '/terminos-calificacion/:id', Component: GradingTermEditContainer },
+    { path: '/tipos-reuniones', Component: MeetingTypeListContainer },
+    { path: '/tipos-reuniones/nuevo', Component: MeetingTypeCreateContainer },
+    { path: '/tipos-reuniones/:id', Component: MeetingTypeEditContainer },
+    { path: '/codigos-asistencia', Component: AttendanceCodeListContainer },
+    { path: '/codigos-asistencia/nuevo', Component: AttendanceCodeCreateContainer },
+    { path: '/codigos-asistencia/:id', Component: AttendanceCodeEditContainer },
+    { path: '/escalas-comportamiento', Component: BehaviorScaleListContainer },
+    { path: '/escalas-comportamiento/nuevo', Component: BehaviorScaleCreateContainer },
+    { path: '/escalas-comportamiento/:id', Component: BehaviorScaleEditContainer },
 ], {
     basename: isStandalone ? '/' : '/escolar',
 });

--- a/src/router.ts
+++ b/src/router.ts
@@ -30,9 +30,7 @@ import { AttendanceCodeCreateContainer } from "./scolar/presentation/ui/Attendan
 import { AttendanceCodeEditContainer } from "./scolar/presentation/ui/AttendanceCode/Edit/AttendanceCodeEditContainer";
 import { BehaviorScaleCreateContainer } from './scolar/presentation/ui/BehaviorScale/Create/BehaviorScaleCreateContainer';
 import { BehaviorScaleEditContainer } from './scolar/presentation/ui/BehaviorScale/Edit/BehaviorScaleEditContainer';
-import { ClassScheduleListContainer } from './scolar/presentation/ui/ClassSchedule/List/ClassScheduleListContainer';
-import { ClassScheduleCreateContainer } from './scolar/presentation/ui/ClassSchedule/Create/ClassScheduleCreateContainer';
-import { ClassScheduleEditContainer } from './scolar/presentation/ui/ClassSchedule/Edit/ClassScheduleEditContainer';
+import { ClassScheduleCalendarContainer } from './scolar/presentation/ui/ClassSchedule/Calendar/ClassScheduleCalendarContainer';
 import { AcademicPlanningListContainer } from './scolar/presentation/ui/AcademicPlanning/List/AcademicPlanningListContainer';
 import { AcademicPlanningCreateContainer } from './scolar/presentation/ui/AcademicPlanning/Create/AcademicPlanningCreateContainer';
 import { AcademicPlanningEditContainer } from './scolar/presentation/ui/AcademicPlanning/Edit/AcademicPlanningEditContainer';
@@ -77,7 +75,8 @@ const router = createBrowserRouter([
     { path: '/sistemas-calificacion/nuevo', Component: GradingSystemCreateContainer },
     { path: '/sistemas-calificacion/:id', Component: GradingSystemEditContainer },
     { path: '/terminos-calificacion', Component: GradingTermListContainer },
-        { path: '/terminos-calificacion/:id', Component: GradingTermEditContainer },
+    { path: '/terminos-calificacion/nuevo', Component: GradingTermCreateContainer },
+    { path: '/terminos-calificacion/:id', Component: GradingTermEditContainer },
     { path: '/tipos-reuniones', Component: MeetingTypeListContainer },
     { path: '/tipos-reuniones/nuevo', Component: MeetingTypeCreateContainer },
     { path: '/tipos-reuniones/:id', Component: MeetingTypeEditContainer },
@@ -87,9 +86,7 @@ const router = createBrowserRouter([
     { path: '/escalas-comportamiento', Component: BehaviorScaleListContainer },
     { path: '/escalas-comportamiento/nuevo', Component: BehaviorScaleCreateContainer },
     { path: '/escalas-comportamiento/:id', Component: BehaviorScaleEditContainer },
-    { path: '/horarios-clase', Component: ClassScheduleListContainer },
-    { path: '/horarios-clase/nuevo', Component: ClassScheduleCreateContainer },
-    { path: '/horarios-clase/:id', Component: ClassScheduleEditContainer },
+    { path: '/horarios-clase', Component: ClassScheduleCalendarContainer },
     { path: '/planificaciones-academicas', Component: AcademicPlanningListContainer },
     { path: '/planificaciones-academicas/nuevo', Component: AcademicPlanningCreateContainer },
     { path: '/planificaciones-academicas/:id', Component: AcademicPlanningEditContainer },

--- a/src/router.ts
+++ b/src/router.ts
@@ -28,9 +28,14 @@ import { MeetingTypeEditContainer } from "./scolar/presentation/ui/MeetingType/E
 import { AttendanceCodeListContainer } from "./scolar/presentation/ui/AttendanceCode/List/AttendanceCodeListContainer";
 import { AttendanceCodeCreateContainer } from "./scolar/presentation/ui/AttendanceCode/Create/AttendanceCodeCreateContainer";
 import { AttendanceCodeEditContainer } from "./scolar/presentation/ui/AttendanceCode/Edit/AttendanceCodeEditContainer";
-import { BehaviorScaleListContainer } from "./scolar/presentation/ui/BehaviorScale/List/BehaviorScaleListContainer";
-import { BehaviorScaleCreateContainer } from "./scolar/presentation/ui/BehaviorScale/Create/BehaviorScaleCreateContainer";
-import { BehaviorScaleEditContainer } from "./scolar/presentation/ui/BehaviorScale/Edit/BehaviorScaleEditContainer";
+import { BehaviorScaleCreateContainer } from './scolar/presentation/ui/BehaviorScale/Create/BehaviorScaleCreateContainer';
+import { BehaviorScaleEditContainer } from './scolar/presentation/ui/BehaviorScale/Edit/BehaviorScaleEditContainer';
+import { ClassScheduleListContainer } from './scolar/presentation/ui/ClassSchedule/List/ClassScheduleListContainer';
+import { ClassScheduleCreateContainer } from './scolar/presentation/ui/ClassSchedule/Create/ClassScheduleCreateContainer';
+import { ClassScheduleEditContainer } from './scolar/presentation/ui/ClassSchedule/Edit/ClassScheduleEditContainer';
+import { AcademicPlanningListContainer } from './scolar/presentation/ui/AcademicPlanning/List/AcademicPlanningListContainer';
+import { AcademicPlanningCreateContainer } from './scolar/presentation/ui/AcademicPlanning/Create/AcademicPlanningCreateContainer';
+import { AcademicPlanningEditContainer } from './scolar/presentation/ui/AcademicPlanning/Edit/AcademicPlanningEditContainer';
 
 const isStandalone = !window.singleSpaNavigate;
 
@@ -45,7 +50,9 @@ export const MenuOptions = [
     { name: 'Tipos de evaluación', path: '/tipos-evaluacion' },
     { name: 'Tipos de reunión', path: '/tipos-reuniones' },
     { name: 'Códigos de asistencia', path: '/codigos-asistencia' },
-    { name: 'Escalas de comportamiento', path: '/escalas-comportamiento' }
+    { name: 'Escalas de comportamiento', path: '/escalas-comportamiento' },
+    { name: 'Horarios de clase', path: '/horarios-clase' },
+    { name: 'Planificaciones académicas', path: '/planificaciones-academicas' }
 ];
 
 const router = createBrowserRouter([
@@ -70,8 +77,7 @@ const router = createBrowserRouter([
     { path: '/sistemas-calificacion/nuevo', Component: GradingSystemCreateContainer },
     { path: '/sistemas-calificacion/:id', Component: GradingSystemEditContainer },
     { path: '/terminos-calificacion', Component: GradingTermListContainer },
-    { path: '/terminos-calificacion/nuevo', Component: GradingTermCreateContainer },
-    { path: '/terminos-calificacion/:id', Component: GradingTermEditContainer },
+        { path: '/terminos-calificacion/:id', Component: GradingTermEditContainer },
     { path: '/tipos-reuniones', Component: MeetingTypeListContainer },
     { path: '/tipos-reuniones/nuevo', Component: MeetingTypeCreateContainer },
     { path: '/tipos-reuniones/:id', Component: MeetingTypeEditContainer },
@@ -81,6 +87,12 @@ const router = createBrowserRouter([
     { path: '/escalas-comportamiento', Component: BehaviorScaleListContainer },
     { path: '/escalas-comportamiento/nuevo', Component: BehaviorScaleCreateContainer },
     { path: '/escalas-comportamiento/:id', Component: BehaviorScaleEditContainer },
+    { path: '/horarios-clase', Component: ClassScheduleListContainer },
+    { path: '/horarios-clase/nuevo', Component: ClassScheduleCreateContainer },
+    { path: '/horarios-clase/:id', Component: ClassScheduleEditContainer },
+    { path: '/planificaciones-academicas', Component: AcademicPlanningListContainer },
+    { path: '/planificaciones-academicas/nuevo', Component: AcademicPlanningCreateContainer },
+    { path: '/planificaciones-academicas/:id', Component: AcademicPlanningEditContainer },
 ], {
     basename: isStandalone ? '/' : '/escolar',
 });

--- a/src/scolar/application/useCases/academicPlannings/createAcademicPlanningUseCase.ts
+++ b/src/scolar/application/useCases/academicPlannings/createAcademicPlanningUseCase.ts
@@ -1,0 +1,30 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { AcademicPlanning } from "@/scolar/domain/entities/academicPlanning";
+import { AcademicPlanningService } from "@/scolar/domain/services/AcademicPlanningService";
+import { ACADEMIC_PLANNING_SERVICE } from "@/scolar/domain/symbols/AcademicPlanningSymbol";
+import { injectable, inject } from "inversify";
+import { Either, Right, Left } from "purify-ts/Either";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+
+export class CreateAcademicPlanningCommand extends UseCaseCommand<AcademicPlanning> {}
+
+export type CreateAcademicPlanningUseCase = UseCase<AcademicPlanning, CreateAcademicPlanningCommand>;
+
+@injectable()
+export class CreateAcademicPlanningUseCaseImpl implements CreateAcademicPlanningUseCase {
+    constructor(
+        @inject(ACADEMIC_PLANNING_SERVICE) private service: AcademicPlanningService,
+        @inject(LOGGER) private logger: Logger,
+    ) {}
+    async execute(command: CreateAcademicPlanningCommand): Promise<Either<Failure[], AcademicPlanning | undefined>> {
+        try {
+            const result = await this.service.create(command.data);
+            return Right(result);
+        } catch (error) {
+            this.logger.error("Error creating academic planning: " + JSON.stringify(error));
+            return Left([]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/academicPlannings/deleteAcademicPlanningUseCase.ts
+++ b/src/scolar/application/useCases/academicPlannings/deleteAcademicPlanningUseCase.ts
@@ -1,0 +1,29 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { AcademicPlanningService } from "@/scolar/domain/services/AcademicPlanningService";
+import { ACADEMIC_PLANNING_SERVICE } from "@/scolar/domain/symbols/AcademicPlanningSymbol";
+import { injectable, inject } from "inversify";
+import { Either, Right, Left } from "purify-ts/Either";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+
+export class DeleteAcademicPlanningCommand extends UseCaseCommand<number> {}
+
+export type DeleteAcademicPlanningUseCase = UseCase<void, DeleteAcademicPlanningCommand>;
+
+@injectable()
+export class DeleteAcademicPlanningUseCaseImpl implements DeleteAcademicPlanningUseCase {
+    constructor(
+        @inject(ACADEMIC_PLANNING_SERVICE) private service: AcademicPlanningService,
+        @inject(LOGGER) private logger: Logger,
+    ) {}
+    async execute(command: DeleteAcademicPlanningCommand): Promise<Either<Failure[], void>> {
+        try {
+            await this.service.delete(command.data);
+            return Right(undefined);
+        } catch (error) {
+            this.logger.error("Error deleting academic planning: " + JSON.stringify(error));
+            return Left([]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/academicPlannings/getAcademicPlanningUseCase.ts
+++ b/src/scolar/application/useCases/academicPlannings/getAcademicPlanningUseCase.ts
@@ -1,0 +1,30 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { AcademicPlanning } from "@/scolar/domain/entities/academicPlanning";
+import { AcademicPlanningService } from "@/scolar/domain/services/AcademicPlanningService";
+import { ACADEMIC_PLANNING_SERVICE } from "@/scolar/domain/symbols/AcademicPlanningSymbol";
+import { injectable, inject } from "inversify";
+import { Either, Right, Left } from "purify-ts/Either";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+
+export class GetAcademicPlanningCommand extends UseCaseCommand<number> {}
+
+export type GetAcademicPlanningUseCase = UseCase<AcademicPlanning, GetAcademicPlanningCommand>;
+
+@injectable()
+export class GetAcademicPlanningUseCaseImpl implements GetAcademicPlanningUseCase {
+    constructor(
+        @inject(ACADEMIC_PLANNING_SERVICE) private service: AcademicPlanningService,
+        @inject(LOGGER) private logger: Logger,
+    ) {}
+    async execute(command: GetAcademicPlanningCommand): Promise<Either<Failure[], AcademicPlanning | undefined>> {
+        try {
+            const result = await this.service.get(command.data);
+            return Right(result);
+        } catch (error) {
+            this.logger.error("Error getting academic planning: " + JSON.stringify(error));
+            return Left([]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/academicPlannings/listAcademicPlanningsUseCase.ts
+++ b/src/scolar/application/useCases/academicPlannings/listAcademicPlanningsUseCase.ts
@@ -1,0 +1,31 @@
+import { PaginateUseCaseCommand, UseCase } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { AcademicPlanning } from "@/scolar/domain/entities/academicPlanning";
+import { AcademicPlanningService } from "@/scolar/domain/services/AcademicPlanningService";
+import { ACADEMIC_PLANNING_SERVICE } from "@/scolar/domain/symbols/AcademicPlanningSymbol";
+import { injectable, inject } from "inversify";
+import { Either, Right, Left } from "purify-ts/Either";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+
+export class ListAcademicPlanningsCommand extends PaginateUseCaseCommand {}
+
+export type ListAcademicPlanningsUseCase = UseCase<PaginatedResult<AcademicPlanning>, ListAcademicPlanningsCommand>;
+
+@injectable()
+export class ListAcademicPlanningsUseCaseImpl implements ListAcademicPlanningsUseCase {
+    constructor(
+        @inject(ACADEMIC_PLANNING_SERVICE) private service: AcademicPlanningService,
+        @inject(LOGGER) private logger: Logger,
+    ) {}
+    async execute(command: ListAcademicPlanningsCommand): Promise<Either<Failure[], PaginatedResult<AcademicPlanning> | undefined>> {
+        try {
+            const result = await this.service.all(command.data.page, command.data.perPage, command.data.search, command.data.orderBy);
+            return Right(result);
+        } catch (error) {
+            this.logger.error("Error listing academic plannings: " + JSON.stringify(error));
+            return Left([]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/academicPlannings/updateAcademicPlanningUseCase.ts
+++ b/src/scolar/application/useCases/academicPlannings/updateAcademicPlanningUseCase.ts
@@ -1,0 +1,30 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { AcademicPlanning } from "@/scolar/domain/entities/academicPlanning";
+import { AcademicPlanningService } from "@/scolar/domain/services/AcademicPlanningService";
+import { ACADEMIC_PLANNING_SERVICE } from "@/scolar/domain/symbols/AcademicPlanningSymbol";
+import { injectable, inject } from "inversify";
+import { Either, Right, Left } from "purify-ts/Either";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+
+export class UpdateAcademicPlanningCommand extends UseCaseCommand<AcademicPlanning> {}
+
+export type UpdateAcademicPlanningUseCase = UseCase<AcademicPlanning, UpdateAcademicPlanningCommand>;
+
+@injectable()
+export class UpdateAcademicPlanningUseCaseImpl implements UpdateAcademicPlanningUseCase {
+    constructor(
+        @inject(ACADEMIC_PLANNING_SERVICE) private service: AcademicPlanningService,
+        @inject(LOGGER) private logger: Logger,
+    ) {}
+    async execute(command: UpdateAcademicPlanningCommand): Promise<Either<Failure[], AcademicPlanning | undefined>> {
+        try {
+            const result = await this.service.update(command.data);
+            return Right(result);
+        } catch (error) {
+            this.logger.error("Error updating academic planning: " + JSON.stringify(error));
+            return Left([]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/attendanceCodes/createAttendanceCodeUseCase.ts
+++ b/src/scolar/application/useCases/attendanceCodes/createAttendanceCodeUseCase.ts
@@ -1,0 +1,30 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { AttendanceCode } from "@/scolar/domain/entities/attendanceCode";
+import { AttendanceCodeService } from "@/scolar/domain/services/AttendanceCodeService";
+import { ATTENDANCE_CODE_SERVICE } from "@/scolar/domain/symbols/AttendanceCodeSymbol";
+import { injectable, inject } from "inversify";
+import { Either, Right, Left } from "purify-ts/Either";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+
+export class CreateAttendanceCodeCommand extends UseCaseCommand<AttendanceCode> {}
+
+export type CreateAttendanceCodeUseCase = UseCase<AttendanceCode, CreateAttendanceCodeCommand>;
+
+@injectable()
+export class CreateAttendanceCodeUseCaseImpl implements CreateAttendanceCodeUseCase {
+    constructor(
+        @inject(ATTENDANCE_CODE_SERVICE) private service: AttendanceCodeService,
+        @inject(LOGGER) private logger: Logger,
+    ) {}
+    async execute(command: CreateAttendanceCodeCommand): Promise<Either<Failure[], AttendanceCode | undefined>> {
+        try {
+            const result = await this.service.create(command.data);
+            return Right(result);
+        } catch (error) {
+            this.logger.error("Error creating attendance code: " + JSON.stringify(error));
+            return Left([]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/attendanceCodes/deleteAttendanceCodeUseCase.ts
+++ b/src/scolar/application/useCases/attendanceCodes/deleteAttendanceCodeUseCase.ts
@@ -1,0 +1,29 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { AttendanceCodeService } from "@/scolar/domain/services/AttendanceCodeService";
+import { ATTENDANCE_CODE_SERVICE } from "@/scolar/domain/symbols/AttendanceCodeSymbol";
+import { injectable, inject } from "inversify";
+import { Either, Right, Left } from "purify-ts/Either";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+
+export class DeleteAttendanceCodeCommand extends UseCaseCommand<number> {}
+
+export type DeleteAttendanceCodeUseCase = UseCase<void, DeleteAttendanceCodeCommand>;
+
+@injectable()
+export class DeleteAttendanceCodeUseCaseImpl implements DeleteAttendanceCodeUseCase {
+    constructor(
+        @inject(ATTENDANCE_CODE_SERVICE) private service: AttendanceCodeService,
+        @inject(LOGGER) private logger: Logger,
+    ) {}
+    async execute(command: DeleteAttendanceCodeCommand): Promise<Either<Failure[], void>> {
+        try {
+            await this.service.delete(command.data);
+            return Right(undefined);
+        } catch (error) {
+            this.logger.error("Error deleting attendance code: " + JSON.stringify(error));
+            return Left([]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/attendanceCodes/getAttendanceCodeUseCase.ts
+++ b/src/scolar/application/useCases/attendanceCodes/getAttendanceCodeUseCase.ts
@@ -1,0 +1,30 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { AttendanceCode } from "@/scolar/domain/entities/attendanceCode";
+import { AttendanceCodeService } from "@/scolar/domain/services/AttendanceCodeService";
+import { ATTENDANCE_CODE_SERVICE } from "@/scolar/domain/symbols/AttendanceCodeSymbol";
+import { injectable, inject } from "inversify";
+import { Either, Right, Left } from "purify-ts/Either";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+
+export class GetAttendanceCodeCommand extends UseCaseCommand<number> {}
+
+export type GetAttendanceCodeUseCase = UseCase<AttendanceCode, GetAttendanceCodeCommand>;
+
+@injectable()
+export class GetAttendanceCodeUseCaseImpl implements GetAttendanceCodeUseCase {
+    constructor(
+        @inject(ATTENDANCE_CODE_SERVICE) private service: AttendanceCodeService,
+        @inject(LOGGER) private logger: Logger,
+    ) {}
+    async execute(command: GetAttendanceCodeCommand): Promise<Either<Failure[], AttendanceCode | undefined>> {
+        try {
+            const result = await this.service.get(command.data);
+            return Right(result);
+        } catch (error) {
+            this.logger.error("Error getting attendance code: " + JSON.stringify(error));
+            return Left([]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/attendanceCodes/listAttendanceCodesUseCase.ts
+++ b/src/scolar/application/useCases/attendanceCodes/listAttendanceCodesUseCase.ts
@@ -1,0 +1,31 @@
+import { PaginateUseCaseCommand, UseCase } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { AttendanceCode } from "@/scolar/domain/entities/attendanceCode";
+import { AttendanceCodeService } from "@/scolar/domain/services/AttendanceCodeService";
+import { ATTENDANCE_CODE_SERVICE } from "@/scolar/domain/symbols/AttendanceCodeSymbol";
+import { injectable, inject } from "inversify";
+import { Either, Right, Left } from "purify-ts/Either";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+
+export class ListAttendanceCodesCommand extends PaginateUseCaseCommand {}
+
+export type ListAttendanceCodesUseCase = UseCase<PaginatedResult<AttendanceCode>, ListAttendanceCodesCommand>
+
+@injectable()
+export class ListAttendanceCodesUseCaseImpl implements ListAttendanceCodesUseCase {
+    constructor(
+        @inject(ATTENDANCE_CODE_SERVICE) private service: AttendanceCodeService,
+        @inject(LOGGER) private logger: Logger,
+    ) {}
+    async execute(command: ListAttendanceCodesCommand): Promise<Either<Failure[], PaginatedResult<AttendanceCode> | undefined>> {
+        try {
+            const result = await this.service.all(command.data.page, command.data.perPage, command.data.search, command.data.orderBy);
+            return Right(result);
+        } catch (error) {
+            this.logger.error("Error listing attendance codes: " + JSON.stringify(error));
+            return Left([]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/attendanceCodes/updateAttendanceCodeUseCase.ts
+++ b/src/scolar/application/useCases/attendanceCodes/updateAttendanceCodeUseCase.ts
@@ -1,0 +1,30 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { AttendanceCode } from "@/scolar/domain/entities/attendanceCode";
+import { AttendanceCodeService } from "@/scolar/domain/services/AttendanceCodeService";
+import { ATTENDANCE_CODE_SERVICE } from "@/scolar/domain/symbols/AttendanceCodeSymbol";
+import { injectable, inject } from "inversify";
+import { Either, Right, Left } from "purify-ts/Either";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+
+export class UpdateAttendanceCodeCommand extends UseCaseCommand<AttendanceCode> {}
+
+export type UpdateAttendanceCodeUseCase = UseCase<AttendanceCode, UpdateAttendanceCodeCommand>;
+
+@injectable()
+export class UpdateAttendanceCodeUseCaseImpl implements UpdateAttendanceCodeUseCase {
+    constructor(
+        @inject(ATTENDANCE_CODE_SERVICE) private service: AttendanceCodeService,
+        @inject(LOGGER) private logger: Logger,
+    ) {}
+    async execute(command: UpdateAttendanceCodeCommand): Promise<Either<Failure[], AttendanceCode | undefined>> {
+        try {
+            const result = await this.service.update(command.data);
+            return Right(result);
+        } catch (error) {
+            this.logger.error("Error updating attendance code: " + JSON.stringify(error));
+            return Left([]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/behaviorScales/createBehaviorScaleUseCase.ts
+++ b/src/scolar/application/useCases/behaviorScales/createBehaviorScaleUseCase.ts
@@ -1,0 +1,30 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { BehaviorScale } from "@/scolar/domain/entities/behaviorScale";
+import { BehaviorScaleService } from "@/scolar/domain/services/BehaviorScaleService";
+import { BEHAVIOR_SCALE_SERVICE } from "@/scolar/domain/symbols/BehaviorScaleSymbol";
+import { injectable, inject } from "inversify";
+import { Either, Right, Left } from "purify-ts/Either";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+
+export class CreateBehaviorScaleCommand extends UseCaseCommand<BehaviorScale> {}
+
+export type CreateBehaviorScaleUseCase = UseCase<BehaviorScale, CreateBehaviorScaleCommand>;
+
+@injectable()
+export class CreateBehaviorScaleUseCaseImpl implements CreateBehaviorScaleUseCase {
+    constructor(
+        @inject(BEHAVIOR_SCALE_SERVICE) private service: BehaviorScaleService,
+        @inject(LOGGER) private logger: Logger,
+    ) {}
+    async execute(command: CreateBehaviorScaleCommand): Promise<Either<Failure[], BehaviorScale | undefined>> {
+        try {
+            const result = await this.service.create(command.data);
+            return Right(result);
+        } catch (error) {
+            this.logger.error("Error creating behavior scale: " + JSON.stringify(error));
+            return Left([]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/behaviorScales/deleteBehaviorScaleUseCase.ts
+++ b/src/scolar/application/useCases/behaviorScales/deleteBehaviorScaleUseCase.ts
@@ -1,0 +1,29 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { BehaviorScaleService } from "@/scolar/domain/services/BehaviorScaleService";
+import { BEHAVIOR_SCALE_SERVICE } from "@/scolar/domain/symbols/BehaviorScaleSymbol";
+import { injectable, inject } from "inversify";
+import { Either, Right, Left } from "purify-ts/Either";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+
+export class DeleteBehaviorScaleCommand extends UseCaseCommand<number> {}
+
+export type DeleteBehaviorScaleUseCase = UseCase<void, DeleteBehaviorScaleCommand>;
+
+@injectable()
+export class DeleteBehaviorScaleUseCaseImpl implements DeleteBehaviorScaleUseCase {
+    constructor(
+        @inject(BEHAVIOR_SCALE_SERVICE) private service: BehaviorScaleService,
+        @inject(LOGGER) private logger: Logger,
+    ) {}
+    async execute(command: DeleteBehaviorScaleCommand): Promise<Either<Failure[], void>> {
+        try {
+            await this.service.delete(command.data);
+            return Right(undefined);
+        } catch (error) {
+            this.logger.error("Error deleting behavior scale: " + JSON.stringify(error));
+            return Left([]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/behaviorScales/getBehaviorScaleUseCase.ts
+++ b/src/scolar/application/useCases/behaviorScales/getBehaviorScaleUseCase.ts
@@ -1,0 +1,30 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { BehaviorScale } from "@/scolar/domain/entities/behaviorScale";
+import { BehaviorScaleService } from "@/scolar/domain/services/BehaviorScaleService";
+import { BEHAVIOR_SCALE_SERVICE } from "@/scolar/domain/symbols/BehaviorScaleSymbol";
+import { injectable, inject } from "inversify";
+import { Either, Right, Left } from "purify-ts/Either";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+
+export class GetBehaviorScaleCommand extends UseCaseCommand<number> {}
+
+export type GetBehaviorScaleUseCase = UseCase<BehaviorScale, GetBehaviorScaleCommand>;
+
+@injectable()
+export class GetBehaviorScaleUseCaseImpl implements GetBehaviorScaleUseCase {
+    constructor(
+        @inject(BEHAVIOR_SCALE_SERVICE) private service: BehaviorScaleService,
+        @inject(LOGGER) private logger: Logger,
+    ) {}
+    async execute(command: GetBehaviorScaleCommand): Promise<Either<Failure[], BehaviorScale | undefined>> {
+        try {
+            const result = await this.service.get(command.data);
+            return Right(result);
+        } catch (error) {
+            this.logger.error("Error getting behavior scale: " + JSON.stringify(error));
+            return Left([]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/behaviorScales/listBehaviorScalesUseCase.ts
+++ b/src/scolar/application/useCases/behaviorScales/listBehaviorScalesUseCase.ts
@@ -1,0 +1,31 @@
+import { PaginateUseCaseCommand, UseCase } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { BehaviorScale } from "@/scolar/domain/entities/behaviorScale";
+import { BehaviorScaleService } from "@/scolar/domain/services/BehaviorScaleService";
+import { BEHAVIOR_SCALE_SERVICE } from "@/scolar/domain/symbols/BehaviorScaleSymbol";
+import { injectable, inject } from "inversify";
+import { Either, Right, Left } from "purify-ts/Either";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+
+export class ListBehaviorScalesCommand extends PaginateUseCaseCommand {}
+
+export type ListBehaviorScalesUseCase = UseCase<PaginatedResult<BehaviorScale>, ListBehaviorScalesCommand>
+
+@injectable()
+export class ListBehaviorScalesUseCaseImpl implements ListBehaviorScalesUseCase {
+    constructor(
+        @inject(BEHAVIOR_SCALE_SERVICE) private service: BehaviorScaleService,
+        @inject(LOGGER) private logger: Logger,
+    ) {}
+    async execute(command: ListBehaviorScalesCommand): Promise<Either<Failure[], PaginatedResult<BehaviorScale> | undefined>> {
+        try {
+            const result = await this.service.all(command.data.page, command.data.perPage, command.data.search, command.data.orderBy);
+            return Right(result);
+        } catch (error) {
+            this.logger.error("Error listing behavior scales: " + JSON.stringify(error));
+            return Left([]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/behaviorScales/updateBehaviorScaleUseCase.ts
+++ b/src/scolar/application/useCases/behaviorScales/updateBehaviorScaleUseCase.ts
@@ -1,0 +1,30 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { BehaviorScale } from "@/scolar/domain/entities/behaviorScale";
+import { BehaviorScaleService } from "@/scolar/domain/services/BehaviorScaleService";
+import { BEHAVIOR_SCALE_SERVICE } from "@/scolar/domain/symbols/BehaviorScaleSymbol";
+import { injectable, inject } from "inversify";
+import { Either, Right, Left } from "purify-ts/Either";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+
+export class UpdateBehaviorScaleCommand extends UseCaseCommand<BehaviorScale> {}
+
+export type UpdateBehaviorScaleUseCase = UseCase<BehaviorScale, UpdateBehaviorScaleCommand>;
+
+@injectable()
+export class UpdateBehaviorScaleUseCaseImpl implements UpdateBehaviorScaleUseCase {
+    constructor(
+        @inject(BEHAVIOR_SCALE_SERVICE) private service: BehaviorScaleService,
+        @inject(LOGGER) private logger: Logger,
+    ) {}
+    async execute(command: UpdateBehaviorScaleCommand): Promise<Either<Failure[], BehaviorScale | undefined>> {
+        try {
+            const result = await this.service.update(command.data);
+            return Right(result);
+        } catch (error) {
+            this.logger.error("Error updating behavior scale: " + JSON.stringify(error));
+            return Left([]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/classSchedules/createClassScheduleUseCase.ts
+++ b/src/scolar/application/useCases/classSchedules/createClassScheduleUseCase.ts
@@ -1,0 +1,30 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { ClassSchedule } from "@/scolar/domain/entities/classSchedule";
+import { ClassScheduleService } from "@/scolar/domain/services/ClassScheduleService";
+import { CLASS_SCHEDULE_SERVICE } from "@/scolar/domain/symbols/ClassScheduleSymbol";
+import { injectable, inject } from "inversify";
+import { Either, Right, Left } from "purify-ts/Either";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+
+export class CreateClassScheduleCommand extends UseCaseCommand<ClassSchedule> {}
+
+export type CreateClassScheduleUseCase = UseCase<ClassSchedule, CreateClassScheduleCommand>;
+
+@injectable()
+export class CreateClassScheduleUseCaseImpl implements CreateClassScheduleUseCase {
+    constructor(
+        @inject(CLASS_SCHEDULE_SERVICE) private service: ClassScheduleService,
+        @inject(LOGGER) private logger: Logger,
+    ) {}
+    async execute(command: CreateClassScheduleCommand): Promise<Either<Failure[], ClassSchedule | undefined>> {
+        try {
+            const result = await this.service.create(command.data);
+            return Right(result);
+        } catch (error) {
+            this.logger.error("Error creating class schedule: " + JSON.stringify(error));
+            return Left([]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/classSchedules/deleteClassScheduleUseCase.ts
+++ b/src/scolar/application/useCases/classSchedules/deleteClassScheduleUseCase.ts
@@ -1,0 +1,29 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { ClassScheduleService } from "@/scolar/domain/services/ClassScheduleService";
+import { CLASS_SCHEDULE_SERVICE } from "@/scolar/domain/symbols/ClassScheduleSymbol";
+import { injectable, inject } from "inversify";
+import { Either, Right, Left } from "purify-ts/Either";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+
+export class DeleteClassScheduleCommand extends UseCaseCommand<number> {}
+
+export type DeleteClassScheduleUseCase = UseCase<void, DeleteClassScheduleCommand>;
+
+@injectable()
+export class DeleteClassScheduleUseCaseImpl implements DeleteClassScheduleUseCase {
+    constructor(
+        @inject(CLASS_SCHEDULE_SERVICE) private service: ClassScheduleService,
+        @inject(LOGGER) private logger: Logger,
+    ) {}
+    async execute(command: DeleteClassScheduleCommand): Promise<Either<Failure[], void>> {
+        try {
+            await this.service.delete(command.data);
+            return Right(undefined);
+        } catch (error) {
+            this.logger.error("Error deleting class schedule: " + JSON.stringify(error));
+            return Left([]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/classSchedules/getClassScheduleUseCase.ts
+++ b/src/scolar/application/useCases/classSchedules/getClassScheduleUseCase.ts
@@ -1,0 +1,30 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { ClassSchedule } from "@/scolar/domain/entities/classSchedule";
+import { ClassScheduleService } from "@/scolar/domain/services/ClassScheduleService";
+import { CLASS_SCHEDULE_SERVICE } from "@/scolar/domain/symbols/ClassScheduleSymbol";
+import { injectable, inject } from "inversify";
+import { Either, Right, Left } from "purify-ts/Either";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+
+export class GetClassScheduleCommand extends UseCaseCommand<number> {}
+
+export type GetClassScheduleUseCase = UseCase<ClassSchedule, GetClassScheduleCommand>;
+
+@injectable()
+export class GetClassScheduleUseCaseImpl implements GetClassScheduleUseCase {
+    constructor(
+        @inject(CLASS_SCHEDULE_SERVICE) private service: ClassScheduleService,
+        @inject(LOGGER) private logger: Logger,
+    ) {}
+    async execute(command: GetClassScheduleCommand): Promise<Either<Failure[], ClassSchedule | undefined>> {
+        try {
+            const result = await this.service.get(command.data);
+            return Right(result);
+        } catch (error) {
+            this.logger.error("Error getting class schedule: " + JSON.stringify(error));
+            return Left([]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/classSchedules/listClassSchedulesUseCase.ts
+++ b/src/scolar/application/useCases/classSchedules/listClassSchedulesUseCase.ts
@@ -1,0 +1,31 @@
+import { PaginateUseCaseCommand, UseCase } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { ClassSchedule } from "@/scolar/domain/entities/classSchedule";
+import { ClassScheduleService } from "@/scolar/domain/services/ClassScheduleService";
+import { CLASS_SCHEDULE_SERVICE } from "@/scolar/domain/symbols/ClassScheduleSymbol";
+import { injectable, inject } from "inversify";
+import { Either, Right, Left } from "purify-ts/Either";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+
+export class ListClassSchedulesCommand extends PaginateUseCaseCommand {}
+
+export type ListClassSchedulesUseCase = UseCase<PaginatedResult<ClassSchedule>, ListClassSchedulesCommand>;
+
+@injectable()
+export class ListClassSchedulesUseCaseImpl implements ListClassSchedulesUseCase {
+    constructor(
+        @inject(CLASS_SCHEDULE_SERVICE) private service: ClassScheduleService,
+        @inject(LOGGER) private logger: Logger,
+    ) {}
+    async execute(command: ListClassSchedulesCommand): Promise<Either<Failure[], PaginatedResult<ClassSchedule> | undefined>> {
+        try {
+            const result = await this.service.all(command.data.page, command.data.perPage, command.data.search, command.data.orderBy);
+            return Right(result);
+        } catch (error) {
+            this.logger.error("Error listing class schedules: " + JSON.stringify(error));
+            return Left([]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/classSchedules/updateClassScheduleUseCase.ts
+++ b/src/scolar/application/useCases/classSchedules/updateClassScheduleUseCase.ts
@@ -1,0 +1,30 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { ClassSchedule } from "@/scolar/domain/entities/classSchedule";
+import { ClassScheduleService } from "@/scolar/domain/services/ClassScheduleService";
+import { CLASS_SCHEDULE_SERVICE } from "@/scolar/domain/symbols/ClassScheduleSymbol";
+import { injectable, inject } from "inversify";
+import { Either, Right, Left } from "purify-ts/Either";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+
+export class UpdateClassScheduleCommand extends UseCaseCommand<ClassSchedule> {}
+
+export type UpdateClassScheduleUseCase = UseCase<ClassSchedule, UpdateClassScheduleCommand>;
+
+@injectable()
+export class UpdateClassScheduleUseCaseImpl implements UpdateClassScheduleUseCase {
+    constructor(
+        @inject(CLASS_SCHEDULE_SERVICE) private service: ClassScheduleService,
+        @inject(LOGGER) private logger: Logger,
+    ) {}
+    async execute(command: UpdateClassScheduleCommand): Promise<Either<Failure[], ClassSchedule | undefined>> {
+        try {
+            const result = await this.service.update(command.data);
+            return Right(result);
+        } catch (error) {
+            this.logger.error("Error updating class schedule: " + JSON.stringify(error));
+            return Left([]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/meetingTypes/createMeetingTypeUseCase.ts
+++ b/src/scolar/application/useCases/meetingTypes/createMeetingTypeUseCase.ts
@@ -1,0 +1,30 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { MeetingType } from "@/scolar/domain/entities/meetingType";
+import { MeetingTypeService } from "@/scolar/domain/services/MeetingTypeService";
+import { MEETING_TYPE_SERVICE } from "@/scolar/domain/symbols/MeetingTypeSymbol";
+import { injectable, inject } from "inversify";
+import { Either, Right, Left } from "purify-ts/Either";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+
+export class CreateMeetingTypeCommand extends UseCaseCommand<MeetingType> {}
+
+export type CreateMeetingTypeUseCase = UseCase<MeetingType, CreateMeetingTypeCommand>;
+
+@injectable()
+export class CreateMeetingTypeUseCaseImpl implements CreateMeetingTypeUseCase {
+    constructor(
+        @inject(MEETING_TYPE_SERVICE) private service: MeetingTypeService,
+        @inject(LOGGER) private logger: Logger,
+    ) {}
+    async execute(command: CreateMeetingTypeCommand): Promise<Either<Failure[], MeetingType | undefined>> {
+        try {
+            const result = await this.service.create(command.data);
+            return Right(result);
+        } catch (error) {
+            this.logger.error("Error creating meeting type: " + JSON.stringify(error));
+            return Left([]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/meetingTypes/deleteMeetingTypeUseCase.ts
+++ b/src/scolar/application/useCases/meetingTypes/deleteMeetingTypeUseCase.ts
@@ -1,0 +1,29 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { MeetingTypeService } from "@/scolar/domain/services/MeetingTypeService";
+import { MEETING_TYPE_SERVICE } from "@/scolar/domain/symbols/MeetingTypeSymbol";
+import { injectable, inject } from "inversify";
+import { Either, Right, Left } from "purify-ts/Either";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+
+export class DeleteMeetingTypeCommand extends UseCaseCommand<number> {}
+
+export type DeleteMeetingTypeUseCase = UseCase<void, DeleteMeetingTypeCommand>;
+
+@injectable()
+export class DeleteMeetingTypeUseCaseImpl implements DeleteMeetingTypeUseCase {
+    constructor(
+        @inject(MEETING_TYPE_SERVICE) private service: MeetingTypeService,
+        @inject(LOGGER) private logger: Logger,
+    ) {}
+    async execute(command: DeleteMeetingTypeCommand): Promise<Either<Failure[], void>> {
+        try {
+            await this.service.delete(command.data);
+            return Right(undefined);
+        } catch (error) {
+            this.logger.error("Error deleting meeting type: " + JSON.stringify(error));
+            return Left([]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/meetingTypes/getMeetingTypeUseCase.ts
+++ b/src/scolar/application/useCases/meetingTypes/getMeetingTypeUseCase.ts
@@ -1,0 +1,30 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { MeetingType } from "@/scolar/domain/entities/meetingType";
+import { MeetingTypeService } from "@/scolar/domain/services/MeetingTypeService";
+import { MEETING_TYPE_SERVICE } from "@/scolar/domain/symbols/MeetingTypeSymbol";
+import { injectable, inject } from "inversify";
+import { Either, Right, Left } from "purify-ts/Either";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+
+export class GetMeetingTypeCommand extends UseCaseCommand<number> {}
+
+export type GetMeetingTypeUseCase = UseCase<MeetingType, GetMeetingTypeCommand>;
+
+@injectable()
+export class GetMeetingTypeUseCaseImpl implements GetMeetingTypeUseCase {
+    constructor(
+        @inject(MEETING_TYPE_SERVICE) private service: MeetingTypeService,
+        @inject(LOGGER) private logger: Logger,
+    ) {}
+    async execute(command: GetMeetingTypeCommand): Promise<Either<Failure[], MeetingType | undefined>> {
+        try {
+            const result = await this.service.get(command.data);
+            return Right(result);
+        } catch (error) {
+            this.logger.error("Error getting meeting type: " + JSON.stringify(error));
+            return Left([]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/meetingTypes/listMeetingTypesUseCase.ts
+++ b/src/scolar/application/useCases/meetingTypes/listMeetingTypesUseCase.ts
@@ -1,0 +1,31 @@
+import { PaginateUseCaseCommand, UseCase } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { MeetingType } from "@/scolar/domain/entities/meetingType";
+import { MeetingTypeService } from "@/scolar/domain/services/MeetingTypeService";
+import { MEETING_TYPE_SERVICE } from "@/scolar/domain/symbols/MeetingTypeSymbol";
+import { injectable, inject } from "inversify";
+import { Either, Right, Left } from "purify-ts/Either";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+
+export class ListMeetingTypesCommand extends PaginateUseCaseCommand {}
+
+export type ListMeetingTypesUseCase = UseCase<PaginatedResult<MeetingType>, ListMeetingTypesCommand>
+
+@injectable()
+export class ListMeetingTypesUseCaseImpl implements ListMeetingTypesUseCase {
+    constructor(
+        @inject(MEETING_TYPE_SERVICE) private service: MeetingTypeService,
+        @inject(LOGGER) private logger: Logger,
+    ) {}
+    async execute(command: ListMeetingTypesCommand): Promise<Either<Failure[], PaginatedResult<MeetingType> | undefined>> {
+        try {
+            const result = await this.service.all(command.data.page, command.data.perPage, command.data.search, command.data.orderBy);
+            return Right(result);
+        } catch (error) {
+            this.logger.error("Error listing meeting types: " + JSON.stringify(error));
+            return Left([]);
+        }
+    }
+}

--- a/src/scolar/application/useCases/meetingTypes/updateMeetingTypeUseCase.ts
+++ b/src/scolar/application/useCases/meetingTypes/updateMeetingTypeUseCase.ts
@@ -1,0 +1,30 @@
+import { UseCase, UseCaseCommand } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { MeetingType } from "@/scolar/domain/entities/meetingType";
+import { MeetingTypeService } from "@/scolar/domain/services/MeetingTypeService";
+import { MEETING_TYPE_SERVICE } from "@/scolar/domain/symbols/MeetingTypeSymbol";
+import { injectable, inject } from "inversify";
+import { Either, Right, Left } from "purify-ts/Either";
+import { LOGGER } from "@/scolar/domain/symbols/SharedSymbol";
+import { Logger } from "@/scolar/infrastructure/services/Logger";
+
+export class UpdateMeetingTypeCommand extends UseCaseCommand<MeetingType> {}
+
+export type UpdateMeetingTypeUseCase = UseCase<MeetingType, UpdateMeetingTypeCommand>;
+
+@injectable()
+export class UpdateMeetingTypeUseCaseImpl implements UpdateMeetingTypeUseCase {
+    constructor(
+        @inject(MEETING_TYPE_SERVICE) private service: MeetingTypeService,
+        @inject(LOGGER) private logger: Logger,
+    ) {}
+    async execute(command: UpdateMeetingTypeCommand): Promise<Either<Failure[], MeetingType | undefined>> {
+        try {
+            const result = await this.service.update(command.data);
+            return Right(result);
+        } catch (error) {
+            this.logger.error("Error updating meeting type: " + JSON.stringify(error));
+            return Left([]);
+        }
+    }
+}

--- a/src/scolar/domain/entities/academicPlanning.ts
+++ b/src/scolar/domain/entities/academicPlanning.ts
@@ -1,0 +1,13 @@
+export class AcademicPlanning {
+    constructor(
+        public id: number,
+        public courseId: number,
+        public parallelId: number,
+        public schoolYearId: number,
+        public subjectId: number,
+        public topic: string,
+        public startDate: string,
+        public endDate: string,
+        public description: string,
+    ) {}
+}

--- a/src/scolar/domain/entities/attendanceCode.ts
+++ b/src/scolar/domain/entities/attendanceCode.ts
@@ -1,0 +1,8 @@
+export class AttendanceCode {
+    constructor(
+        public id: number,
+        public code: string,
+        public description: string,
+        public affectsGrade: boolean,
+    ) {}
+}

--- a/src/scolar/domain/entities/behaviorScale.ts
+++ b/src/scolar/domain/entities/behaviorScale.ts
@@ -1,0 +1,8 @@
+export class BehaviorScale {
+    constructor(
+        public id: number,
+        public name: string,
+        public minScore: string,
+        public maxScore: string,
+    ) {}
+}

--- a/src/scolar/domain/entities/classSchedule.ts
+++ b/src/scolar/domain/entities/classSchedule.ts
@@ -1,0 +1,12 @@
+export class ClassSchedule {
+    constructor(
+        public id: number,
+        public courseId: number,
+        public parallelId: number,
+        public schoolYearId: number,
+        public subjectId: number,
+        public dayOfWeek: string,
+        public startTime: string,
+        public endTime: string,
+    ) {}
+}

--- a/src/scolar/domain/entities/meetingType.ts
+++ b/src/scolar/domain/entities/meetingType.ts
@@ -1,0 +1,7 @@
+export class MeetingType {
+    constructor(
+        public id: number,
+        public name: string,
+        public description: string,
+    ) {}
+}

--- a/src/scolar/domain/inversify.ts
+++ b/src/scolar/domain/inversify.ts
@@ -95,7 +95,22 @@ import { ListBehaviorScalesUseCaseImpl } from "../application/useCases/behaviorS
 import { CreateBehaviorScaleUseCaseImpl } from "../application/useCases/behaviorScales/createBehaviorScaleUseCase";
 import { UpdateBehaviorScaleUseCaseImpl } from "../application/useCases/behaviorScales/updateBehaviorScaleUseCase";
 import { DeleteBehaviorScaleUseCaseImpl } from "../application/useCases/behaviorScales/deleteBehaviorScaleUseCase";
-import { GetBehaviorScaleUseCaseImpl } from "../application/useCases/behaviorScales/getBehaviorScaleUseCase";
+import { CLASS_SCHEDULE_REPOSITORY, CLASS_SCHEDULE_SERVICE, CLASS_SCHEDULE_LIST_USE_CASE, CLASS_SCHEDULE_CREATE_USE_CASE, CLASS_SCHEDULE_UPDATE_USE_CASE, CLASS_SCHEDULE_DELETE_USE_CASE, CLASS_SCHEDULE_GET_USE_CASE } from "./symbols/ClassScheduleSymbol";
+import { ClassScheduleRepositoryImpl } from "../infrastructure/adapters/api/ClassScheduleRepositoryImpl";
+import { ClassScheduleService } from "./services/ClassScheduleService";
+import { ListClassSchedulesUseCaseImpl } from "../application/useCases/classSchedules/listClassSchedulesUseCase";
+import { CreateClassScheduleUseCaseImpl } from "../application/useCases/classSchedules/createClassScheduleUseCase";
+import { UpdateClassScheduleUseCaseImpl } from "../application/useCases/classSchedules/updateClassScheduleUseCase";
+import { DeleteClassScheduleUseCaseImpl } from "../application/useCases/classSchedules/deleteClassScheduleUseCase";
+import { GetClassScheduleUseCaseImpl } from "../application/useCases/classSchedules/getClassScheduleUseCase";
+import { ACADEMIC_PLANNING_REPOSITORY, ACADEMIC_PLANNING_SERVICE, ACADEMIC_PLANNING_LIST_USE_CASE, ACADEMIC_PLANNING_CREATE_USE_CASE, ACADEMIC_PLANNING_UPDATE_USE_CASE, ACADEMIC_PLANNING_DELETE_USE_CASE, ACADEMIC_PLANNING_GET_USE_CASE } from "./symbols/AcademicPlanningSymbol";
+import { AcademicPlanningRepositoryImpl } from "../infrastructure/adapters/api/AcademicPlanningRepositoryImpl";
+import { AcademicPlanningService } from "./services/AcademicPlanningService";
+import { ListAcademicPlanningsUseCaseImpl } from "../application/useCases/academicPlannings/listAcademicPlanningsUseCase";
+import { CreateAcademicPlanningUseCaseImpl } from "../application/useCases/academicPlannings/createAcademicPlanningUseCase";
+import { UpdateAcademicPlanningUseCaseImpl } from "../application/useCases/academicPlannings/updateAcademicPlanningUseCase";
+import { DeleteAcademicPlanningUseCaseImpl } from "../application/useCases/academicPlannings/deleteAcademicPlanningUseCase";
+import { GetAcademicPlanningUseCaseImpl } from "../application/useCases/academicPlannings/getAcademicPlanningUseCase";
 
 const contianerScolar = new ContainerModule(
     (bind) => {
@@ -224,6 +239,26 @@ const contianerScolar = new ContainerModule(
         bind(BEHAVIOR_SCALE_UPDATE_USE_CASE).to(UpdateBehaviorScaleUseCaseImpl)
         bind(BEHAVIOR_SCALE_DELETE_USE_CASE).to(DeleteBehaviorScaleUseCaseImpl)
         bind(BEHAVIOR_SCALE_GET_USE_CASE).to(GetBehaviorScaleUseCaseImpl)
+
+        bind(CLASS_SCHEDULE_REPOSITORY).toDynamicValue(() => {
+            return new ClassScheduleRepositoryImpl(schoolapi);
+        })
+        bind(CLASS_SCHEDULE_SERVICE).to(ClassScheduleService)
+        bind(CLASS_SCHEDULE_LIST_USE_CASE).to(ListClassSchedulesUseCaseImpl)
+        bind(CLASS_SCHEDULE_CREATE_USE_CASE).to(CreateClassScheduleUseCaseImpl)
+        bind(CLASS_SCHEDULE_UPDATE_USE_CASE).to(UpdateClassScheduleUseCaseImpl)
+        bind(CLASS_SCHEDULE_DELETE_USE_CASE).to(DeleteClassScheduleUseCaseImpl)
+        bind(CLASS_SCHEDULE_GET_USE_CASE).to(GetClassScheduleUseCaseImpl)
+
+        bind(ACADEMIC_PLANNING_REPOSITORY).toDynamicValue(() => {
+            return new AcademicPlanningRepositoryImpl(schoolapi);
+        })
+        bind(ACADEMIC_PLANNING_SERVICE).to(AcademicPlanningService)
+        bind(ACADEMIC_PLANNING_LIST_USE_CASE).to(ListAcademicPlanningsUseCaseImpl)
+        bind(ACADEMIC_PLANNING_CREATE_USE_CASE).to(CreateAcademicPlanningUseCaseImpl)
+        bind(ACADEMIC_PLANNING_UPDATE_USE_CASE).to(UpdateAcademicPlanningUseCaseImpl)
+        bind(ACADEMIC_PLANNING_DELETE_USE_CASE).to(DeleteAcademicPlanningUseCaseImpl)
+        bind(ACADEMIC_PLANNING_GET_USE_CASE).to(GetAcademicPlanningUseCaseImpl)
     }
 );
 

--- a/src/scolar/domain/inversify.ts
+++ b/src/scolar/domain/inversify.ts
@@ -72,6 +72,30 @@ import { LOGGER } from "./symbols/SharedSymbol";
 import { Logger } from "../infrastructure/services/Logger";
 import { ListSectionUseCaseImpl } from "../application/useCases/section/listSectionUseCases";
 import { SectionService } from "./services/SectionService";
+import { MEETING_TYPE_REPOSITORY, MEETING_TYPE_SERVICE, MEETING_TYPE_LIST_USE_CASE, MEETING_TYPE_CREATE_USE_CASE, MEETING_TYPE_UPDATE_USE_CASE, MEETING_TYPE_DELETE_USE_CASE, MEETING_TYPE_GET_USE_CASE } from "./symbols/MeetingTypeSymbol";
+import { MeetingTypeRepositoryImpl } from "../infrastructure/adapters/api/MeetingTypeRepositoryImpl";
+import { MeetingTypeService } from "./services/MeetingTypeService";
+import { ListMeetingTypesUseCaseImpl } from "../application/useCases/meetingTypes/listMeetingTypesUseCase";
+import { CreateMeetingTypeUseCaseImpl } from "../application/useCases/meetingTypes/createMeetingTypeUseCase";
+import { UpdateMeetingTypeUseCaseImpl } from "../application/useCases/meetingTypes/updateMeetingTypeUseCase";
+import { DeleteMeetingTypeUseCaseImpl } from "../application/useCases/meetingTypes/deleteMeetingTypeUseCase";
+import { GetMeetingTypeUseCaseImpl } from "../application/useCases/meetingTypes/getMeetingTypeUseCase";
+import { ATTENDANCE_CODE_REPOSITORY, ATTENDANCE_CODE_SERVICE, ATTENDANCE_CODE_LIST_USE_CASE, ATTENDANCE_CODE_CREATE_USE_CASE, ATTENDANCE_CODE_UPDATE_USE_CASE, ATTENDANCE_CODE_DELETE_USE_CASE, ATTENDANCE_CODE_GET_USE_CASE } from "./symbols/AttendanceCodeSymbol";
+import { AttendanceCodeRepositoryImpl } from "../infrastructure/adapters/api/AttendanceCodeRepositoryImpl";
+import { AttendanceCodeService } from "./services/AttendanceCodeService";
+import { ListAttendanceCodesUseCaseImpl } from "../application/useCases/attendanceCodes/listAttendanceCodesUseCase";
+import { CreateAttendanceCodeUseCaseImpl } from "../application/useCases/attendanceCodes/createAttendanceCodeUseCase";
+import { UpdateAttendanceCodeUseCaseImpl } from "../application/useCases/attendanceCodes/updateAttendanceCodeUseCase";
+import { DeleteAttendanceCodeUseCaseImpl } from "../application/useCases/attendanceCodes/deleteAttendanceCodeUseCase";
+import { GetAttendanceCodeUseCaseImpl } from "../application/useCases/attendanceCodes/getAttendanceCodeUseCase";
+import { BEHAVIOR_SCALE_REPOSITORY, BEHAVIOR_SCALE_SERVICE, BEHAVIOR_SCALE_LIST_USE_CASE, BEHAVIOR_SCALE_CREATE_USE_CASE, BEHAVIOR_SCALE_UPDATE_USE_CASE, BEHAVIOR_SCALE_DELETE_USE_CASE, BEHAVIOR_SCALE_GET_USE_CASE } from "./symbols/BehaviorScaleSymbol";
+import { BehaviorScaleRepositoryImpl } from "../infrastructure/adapters/api/BehaviorScaleRepositoryImpl";
+import { BehaviorScaleService } from "./services/BehaviorScaleService";
+import { ListBehaviorScalesUseCaseImpl } from "../application/useCases/behaviorScales/listBehaviorScalesUseCase";
+import { CreateBehaviorScaleUseCaseImpl } from "../application/useCases/behaviorScales/createBehaviorScaleUseCase";
+import { UpdateBehaviorScaleUseCaseImpl } from "../application/useCases/behaviorScales/updateBehaviorScaleUseCase";
+import { DeleteBehaviorScaleUseCaseImpl } from "../application/useCases/behaviorScales/deleteBehaviorScaleUseCase";
+import { GetBehaviorScaleUseCaseImpl } from "../application/useCases/behaviorScales/getBehaviorScaleUseCase";
 
 const contianerScolar = new ContainerModule(
     (bind) => {
@@ -170,6 +194,36 @@ const contianerScolar = new ContainerModule(
         bind(PARALLEL_UPDATE_USECASE).to(UpdateParallelUseCaseImpl)
         bind(PARALLEL_DELETE_USECASE).to(DeleteParallelUseCaseImpl)
         bind(PARALLEL_GET_LIST_BY_COURSE_USECASE).to(ListParallelByCourseUseCaseImpl)
+
+        bind(MEETING_TYPE_REPOSITORY).toDynamicValue(() => {
+            return new MeetingTypeRepositoryImpl(schoolapi);
+        })
+        bind(MEETING_TYPE_SERVICE).to(MeetingTypeService)
+        bind(MEETING_TYPE_LIST_USE_CASE).to(ListMeetingTypesUseCaseImpl)
+        bind(MEETING_TYPE_CREATE_USE_CASE).to(CreateMeetingTypeUseCaseImpl)
+        bind(MEETING_TYPE_UPDATE_USE_CASE).to(UpdateMeetingTypeUseCaseImpl)
+        bind(MEETING_TYPE_DELETE_USE_CASE).to(DeleteMeetingTypeUseCaseImpl)
+        bind(MEETING_TYPE_GET_USE_CASE).to(GetMeetingTypeUseCaseImpl)
+
+        bind(ATTENDANCE_CODE_REPOSITORY).toDynamicValue(() => {
+            return new AttendanceCodeRepositoryImpl(schoolapi);
+        })
+        bind(ATTENDANCE_CODE_SERVICE).to(AttendanceCodeService)
+        bind(ATTENDANCE_CODE_LIST_USE_CASE).to(ListAttendanceCodesUseCaseImpl)
+        bind(ATTENDANCE_CODE_CREATE_USE_CASE).to(CreateAttendanceCodeUseCaseImpl)
+        bind(ATTENDANCE_CODE_UPDATE_USE_CASE).to(UpdateAttendanceCodeUseCaseImpl)
+        bind(ATTENDANCE_CODE_DELETE_USE_CASE).to(DeleteAttendanceCodeUseCaseImpl)
+        bind(ATTENDANCE_CODE_GET_USE_CASE).to(GetAttendanceCodeUseCaseImpl)
+
+        bind(BEHAVIOR_SCALE_REPOSITORY).toDynamicValue(() => {
+            return new BehaviorScaleRepositoryImpl(schoolapi);
+        })
+        bind(BEHAVIOR_SCALE_SERVICE).to(BehaviorScaleService)
+        bind(BEHAVIOR_SCALE_LIST_USE_CASE).to(ListBehaviorScalesUseCaseImpl)
+        bind(BEHAVIOR_SCALE_CREATE_USE_CASE).to(CreateBehaviorScaleUseCaseImpl)
+        bind(BEHAVIOR_SCALE_UPDATE_USE_CASE).to(UpdateBehaviorScaleUseCaseImpl)
+        bind(BEHAVIOR_SCALE_DELETE_USE_CASE).to(DeleteBehaviorScaleUseCaseImpl)
+        bind(BEHAVIOR_SCALE_GET_USE_CASE).to(GetBehaviorScaleUseCaseImpl)
     }
 );
 

--- a/src/scolar/domain/mappers/AcademicPlanningMapper.ts
+++ b/src/scolar/domain/mappers/AcademicPlanningMapper.ts
@@ -1,0 +1,30 @@
+import { AcademicPlanningDto } from "@/scolar/infrastructure/dto/AcademicPlanningDto";
+import { AcademicPlanning } from "../entities/academicPlanning";
+
+export class AcademicPlanningMapper {
+    static toDomain(dto: AcademicPlanningDto): AcademicPlanning {
+        return new AcademicPlanning(
+            dto.id,
+            dto.course_id,
+            dto.parallel_id,
+            dto.school_year_id,
+            dto.subject_id,
+            dto.topic,
+            dto.start_date,
+            dto.end_date,
+            dto.description,
+        );
+    }
+    static toDto(entity: AcademicPlanning): Omit<AcademicPlanningDto, 'id'> {
+        return {
+            course_id: entity.courseId,
+            parallel_id: entity.parallelId,
+            school_year_id: entity.schoolYearId,
+            subject_id: entity.subjectId,
+            topic: entity.topic,
+            start_date: entity.startDate,
+            end_date: entity.endDate,
+            description: entity.description,
+        };
+    }
+}

--- a/src/scolar/domain/mappers/AttendanceCodeMapper.ts
+++ b/src/scolar/domain/mappers/AttendanceCodeMapper.ts
@@ -1,0 +1,15 @@
+import { AttendanceCodeDto } from "@/scolar/infrastructure/dto/AttendanceCodeDto";
+import { AttendanceCode } from "../entities/attendanceCode";
+
+export class AttendanceCodeMapper {
+    static toDomain(dto: AttendanceCodeDto): AttendanceCode {
+        return new AttendanceCode(dto.id, dto.code, dto.description, dto.affectsGrade);
+    }
+    static toDto(entity: AttendanceCode): Omit<AttendanceCodeDto, 'id'> {
+        return {
+            code: entity.code,
+            description: entity.description,
+            affectsGrade: entity.affectsGrade,
+        };
+    }
+}

--- a/src/scolar/domain/mappers/BehaviorScaleMapper.ts
+++ b/src/scolar/domain/mappers/BehaviorScaleMapper.ts
@@ -1,0 +1,15 @@
+import { BehaviorScaleDto } from "@/scolar/infrastructure/dto/BehaviorScaleDto";
+import { BehaviorScale } from "../entities/behaviorScale";
+
+export class BehaviorScaleMapper {
+    static toDomain(dto: BehaviorScaleDto): BehaviorScale {
+        return new BehaviorScale(dto.id, dto.name, dto.minScore, dto.maxScore);
+    }
+    static toDto(entity: BehaviorScale): Omit<BehaviorScaleDto, 'id'> {
+        return {
+            name: entity.name,
+            minScore: entity.minScore,
+            maxScore: entity.maxScore,
+        };
+    }
+}

--- a/src/scolar/domain/mappers/ClassScheduleMapper.ts
+++ b/src/scolar/domain/mappers/ClassScheduleMapper.ts
@@ -1,0 +1,28 @@
+import { ClassScheduleDto } from "@/scolar/infrastructure/dto/ClassScheduleDto";
+import { ClassSchedule } from "../entities/classSchedule";
+
+export class ClassScheduleMapper {
+    static toDomain(dto: ClassScheduleDto): ClassSchedule {
+        return new ClassSchedule(
+            dto.id,
+            dto.course_id,
+            dto.parallel_id,
+            dto.school_year_id,
+            dto.subject_id,
+            dto.day_of_week,
+            dto.start_time,
+            dto.end_time,
+        );
+    }
+    static toDto(entity: ClassSchedule): Omit<ClassScheduleDto, 'id'> {
+        return {
+            course_id: entity.courseId,
+            parallel_id: entity.parallelId,
+            school_year_id: entity.schoolYearId,
+            subject_id: entity.subjectId,
+            day_of_week: entity.dayOfWeek,
+            start_time: entity.startTime,
+            end_time: entity.endTime,
+        };
+    }
+}

--- a/src/scolar/domain/mappers/MeetingTypeMapper.ts
+++ b/src/scolar/domain/mappers/MeetingTypeMapper.ts
@@ -1,0 +1,14 @@
+import { MeetingTypeDto } from "@/scolar/infrastructure/dto/MeetingTypeDto";
+import { MeetingType } from "../entities/meetingType";
+
+export class MeetingTypeMapper {
+    static toDomain(dto: MeetingTypeDto): MeetingType {
+        return new MeetingType(dto.id, dto.name, dto.description);
+    }
+    static toDto(entity: MeetingType): Omit<MeetingTypeDto, 'id'> {
+        return {
+            name: entity.name,
+            description: entity.description,
+        };
+    }
+}

--- a/src/scolar/domain/repositories/AcademicPlanningRepository.ts
+++ b/src/scolar/domain/repositories/AcademicPlanningRepository.ts
@@ -1,0 +1,10 @@
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { AcademicPlanningDto } from "../../infrastructure/dto/AcademicPlanningDto";
+
+export interface AcademicPlanningRepository {
+    findAll(page: number, limit: number, search?: string, orderby?: string[]): Promise<PaginatedResult<AcademicPlanningDto>>;
+    findById(id: number): Promise<AcademicPlanningDto>;
+    create(data: Omit<AcademicPlanningDto, 'id'>): Promise<AcademicPlanningDto>;
+    update(id: number, data: Omit<AcademicPlanningDto, 'id'>): Promise<AcademicPlanningDto>;
+    delete(id: number): Promise<void>;
+}

--- a/src/scolar/domain/repositories/AttendanceCodeRepository.ts
+++ b/src/scolar/domain/repositories/AttendanceCodeRepository.ts
@@ -1,0 +1,10 @@
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { AttendanceCodeDto } from "../../infrastructure/dto/AttendanceCodeDto";
+
+export interface AttendanceCodeRepository {
+    findAll(page: number, limit: number, search?: string, orderby?: string[]): Promise<PaginatedResult<AttendanceCodeDto>>;
+    findById(id: number): Promise<AttendanceCodeDto>;
+    create(data: Omit<AttendanceCodeDto, 'id'>): Promise<AttendanceCodeDto>;
+    update(id: number, data: Omit<AttendanceCodeDto, 'id'>): Promise<AttendanceCodeDto>;
+    delete(id: number): Promise<void>;
+}

--- a/src/scolar/domain/repositories/BehaviorScaleRepository.ts
+++ b/src/scolar/domain/repositories/BehaviorScaleRepository.ts
@@ -1,0 +1,10 @@
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { BehaviorScaleDto } from "../../infrastructure/dto/BehaviorScaleDto";
+
+export interface BehaviorScaleRepository {
+    findAll(page: number, limit: number, search?: string, orderby?: string[]): Promise<PaginatedResult<BehaviorScaleDto>>;
+    findById(id: number): Promise<BehaviorScaleDto>;
+    create(data: Omit<BehaviorScaleDto, 'id'>): Promise<BehaviorScaleDto>;
+    update(id: number, data: Omit<BehaviorScaleDto, 'id'>): Promise<BehaviorScaleDto>;
+    delete(id: number): Promise<void>;
+}

--- a/src/scolar/domain/repositories/ClassScheduleRepository.ts
+++ b/src/scolar/domain/repositories/ClassScheduleRepository.ts
@@ -1,0 +1,10 @@
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { ClassScheduleDto } from "../../infrastructure/dto/ClassScheduleDto";
+
+export interface ClassScheduleRepository {
+    findAll(page: number, limit: number, search?: string, orderby?: string[]): Promise<PaginatedResult<ClassScheduleDto>>;
+    findById(id: number): Promise<ClassScheduleDto>;
+    create(data: Omit<ClassScheduleDto, 'id'>): Promise<ClassScheduleDto>;
+    update(id: number, data: Omit<ClassScheduleDto, 'id'>): Promise<ClassScheduleDto>;
+    delete(id: number): Promise<void>;
+}

--- a/src/scolar/domain/repositories/MeetingTypeRepository.ts
+++ b/src/scolar/domain/repositories/MeetingTypeRepository.ts
@@ -1,0 +1,10 @@
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { MeetingTypeDto } from "../../infrastructure/dto/MeetingTypeDto";
+
+export interface MeetingTypeRepository {
+    findAll(page: number, limit: number, search?: string, orderby?: string[]): Promise<PaginatedResult<MeetingTypeDto>>;
+    findById(id: number): Promise<MeetingTypeDto>;
+    create(data: Omit<MeetingTypeDto, 'id'>): Promise<MeetingTypeDto>;
+    update(id: number, data: Omit<MeetingTypeDto, 'id'>): Promise<MeetingTypeDto>;
+    delete(id: number): Promise<void>;
+}

--- a/src/scolar/domain/services/AcademicPlanningService.ts
+++ b/src/scolar/domain/services/AcademicPlanningService.ts
@@ -1,0 +1,41 @@
+import { inject, injectable } from "inversify";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { AcademicPlanning } from "../entities/academicPlanning";
+import { AcademicPlanningMapper } from "../mappers/AcademicPlanningMapper";
+import { AcademicPlanningRepository } from "../repositories/AcademicPlanningRepository";
+import { ACADEMIC_PLANNING_REPOSITORY } from "../symbols/AcademicPlanningSymbol";
+
+@injectable()
+export class AcademicPlanningService {
+    constructor(
+        @inject(ACADEMIC_PLANNING_REPOSITORY)
+        private repository: AcademicPlanningRepository
+    ) {}
+
+    async all(page: number, size: number, search?: string, order?: string[]) {
+        const res = await this.repository.findAll(page, size, search, order);
+        return {
+            ...res,
+            data: res.data.map(AcademicPlanningMapper.toDomain),
+        } as PaginatedResult<AcademicPlanning>;
+    }
+
+    async get(id: number) {
+        const res = await this.repository.findById(id);
+        return AcademicPlanningMapper.toDomain(res);
+    }
+
+    async create(entity: AcademicPlanning) {
+        const res = await this.repository.create(AcademicPlanningMapper.toDto(entity));
+        return AcademicPlanningMapper.toDomain(res);
+    }
+
+    async update(entity: AcademicPlanning) {
+        const res = await this.repository.update(entity.id, AcademicPlanningMapper.toDto(entity));
+        return AcademicPlanningMapper.toDomain(res);
+    }
+
+    async delete(id: number) {
+        return this.repository.delete(id);
+    }
+}

--- a/src/scolar/domain/services/AttendanceCodeService.ts
+++ b/src/scolar/domain/services/AttendanceCodeService.ts
@@ -1,0 +1,41 @@
+import { inject, injectable } from "inversify";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { AttendanceCode } from "../entities/attendanceCode";
+import { AttendanceCodeMapper } from "../mappers/AttendanceCodeMapper";
+import { AttendanceCodeRepository } from "../repositories/AttendanceCodeRepository";
+import { ATTENDANCE_CODE_REPOSITORY } from "../symbols/AttendanceCodeSymbol";
+
+@injectable()
+export class AttendanceCodeService {
+    constructor(
+        @inject(ATTENDANCE_CODE_REPOSITORY)
+        private repository: AttendanceCodeRepository
+    ) {}
+
+    async all(page: number, size: number, search?: string, order?: string[]) {
+        const res = await this.repository.findAll(page, size, search, order);
+        return {
+            ...res,
+            data: res.data.map(AttendanceCodeMapper.toDomain),
+        } as PaginatedResult<AttendanceCode>;
+    }
+
+    async get(id: number) {
+        const res = await this.repository.findById(id);
+        return AttendanceCodeMapper.toDomain(res);
+    }
+
+    async create(entity: AttendanceCode) {
+        const res = await this.repository.create(AttendanceCodeMapper.toDto(entity));
+        return AttendanceCodeMapper.toDomain(res);
+    }
+
+    async update(entity: AttendanceCode) {
+        const res = await this.repository.update(entity.id, AttendanceCodeMapper.toDto(entity));
+        return AttendanceCodeMapper.toDomain(res);
+    }
+
+    async delete(id: number) {
+        return this.repository.delete(id);
+    }
+}

--- a/src/scolar/domain/services/BehaviorScaleService.ts
+++ b/src/scolar/domain/services/BehaviorScaleService.ts
@@ -1,0 +1,41 @@
+import { inject, injectable } from "inversify";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { BehaviorScale } from "../entities/behaviorScale";
+import { BehaviorScaleMapper } from "../mappers/BehaviorScaleMapper";
+import { BehaviorScaleRepository } from "../repositories/BehaviorScaleRepository";
+import { BEHAVIOR_SCALE_REPOSITORY } from "../symbols/BehaviorScaleSymbol";
+
+@injectable()
+export class BehaviorScaleService {
+    constructor(
+        @inject(BEHAVIOR_SCALE_REPOSITORY)
+        private repository: BehaviorScaleRepository
+    ) {}
+
+    async all(page: number, size: number, search?: string, order?: string[]) {
+        const res = await this.repository.findAll(page, size, search, order);
+        return {
+            ...res,
+            data: res.data.map(BehaviorScaleMapper.toDomain),
+        } as PaginatedResult<BehaviorScale>;
+    }
+
+    async get(id: number) {
+        const res = await this.repository.findById(id);
+        return BehaviorScaleMapper.toDomain(res);
+    }
+
+    async create(entity: BehaviorScale) {
+        const res = await this.repository.create(BehaviorScaleMapper.toDto(entity));
+        return BehaviorScaleMapper.toDomain(res);
+    }
+
+    async update(entity: BehaviorScale) {
+        const res = await this.repository.update(entity.id, BehaviorScaleMapper.toDto(entity));
+        return BehaviorScaleMapper.toDomain(res);
+    }
+
+    async delete(id: number) {
+        return this.repository.delete(id);
+    }
+}

--- a/src/scolar/domain/services/ClassScheduleService.ts
+++ b/src/scolar/domain/services/ClassScheduleService.ts
@@ -1,0 +1,41 @@
+import { inject, injectable } from "inversify";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { ClassSchedule } from "../entities/classSchedule";
+import { ClassScheduleMapper } from "../mappers/ClassScheduleMapper";
+import { ClassScheduleRepository } from "../repositories/ClassScheduleRepository";
+import { CLASS_SCHEDULE_REPOSITORY } from "../symbols/ClassScheduleSymbol";
+
+@injectable()
+export class ClassScheduleService {
+    constructor(
+        @inject(CLASS_SCHEDULE_REPOSITORY)
+        private repository: ClassScheduleRepository
+    ) {}
+
+    async all(page: number, size: number, search?: string, order?: string[]) {
+        const res = await this.repository.findAll(page, size, search, order);
+        return {
+            ...res,
+            data: res.data.map(ClassScheduleMapper.toDomain),
+        } as PaginatedResult<ClassSchedule>;
+    }
+
+    async get(id: number) {
+        const res = await this.repository.findById(id);
+        return ClassScheduleMapper.toDomain(res);
+    }
+
+    async create(entity: ClassSchedule) {
+        const res = await this.repository.create(ClassScheduleMapper.toDto(entity));
+        return ClassScheduleMapper.toDomain(res);
+    }
+
+    async update(entity: ClassSchedule) {
+        const res = await this.repository.update(entity.id, ClassScheduleMapper.toDto(entity));
+        return ClassScheduleMapper.toDomain(res);
+    }
+
+    async delete(id: number) {
+        return this.repository.delete(id);
+    }
+}

--- a/src/scolar/domain/services/MeetingTypeService.ts
+++ b/src/scolar/domain/services/MeetingTypeService.ts
@@ -1,0 +1,41 @@
+import { inject, injectable } from "inversify";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { MeetingType } from "../entities/meetingType";
+import { MeetingTypeMapper } from "../mappers/MeetingTypeMapper";
+import { MeetingTypeRepository } from "../repositories/MeetingTypeRepository";
+import { MEETING_TYPE_REPOSITORY } from "../symbols/MeetingTypeSymbol";
+
+@injectable()
+export class MeetingTypeService {
+    constructor(
+        @inject(MEETING_TYPE_REPOSITORY)
+        private repository: MeetingTypeRepository
+    ) {}
+
+    async all(page: number, size: number, search?: string, order?: string[]) {
+        const res = await this.repository.findAll(page, size, search, order);
+        return {
+            ...res,
+            data: res.data.map(MeetingTypeMapper.toDomain),
+        } as PaginatedResult<MeetingType>;
+    }
+
+    async get(id: number) {
+        const res = await this.repository.findById(id);
+        return MeetingTypeMapper.toDomain(res);
+    }
+
+    async create(entity: MeetingType) {
+        const res = await this.repository.create(MeetingTypeMapper.toDto(entity));
+        return MeetingTypeMapper.toDomain(res);
+    }
+
+    async update(entity: MeetingType) {
+        const res = await this.repository.update(entity.id, MeetingTypeMapper.toDto(entity));
+        return MeetingTypeMapper.toDomain(res);
+    }
+
+    async delete(id: number) {
+        return this.repository.delete(id);
+    }
+}

--- a/src/scolar/domain/symbols/AcademicPlanningSymbol.ts
+++ b/src/scolar/domain/symbols/AcademicPlanningSymbol.ts
@@ -1,0 +1,7 @@
+export const ACADEMIC_PLANNING_REPOSITORY = Symbol('AcademicPlanningRepository');
+export const ACADEMIC_PLANNING_SERVICE = Symbol('AcademicPlanningService');
+export const ACADEMIC_PLANNING_LIST_USE_CASE = Symbol('ListAcademicPlanningUseCase');
+export const ACADEMIC_PLANNING_CREATE_USE_CASE = Symbol('CreateAcademicPlanningUseCase');
+export const ACADEMIC_PLANNING_UPDATE_USE_CASE = Symbol('UpdateAcademicPlanningUseCase');
+export const ACADEMIC_PLANNING_DELETE_USE_CASE = Symbol('DeleteAcademicPlanningUseCase');
+export const ACADEMIC_PLANNING_GET_USE_CASE = Symbol('GetAcademicPlanningUseCase');

--- a/src/scolar/domain/symbols/AttendanceCodeSymbol.ts
+++ b/src/scolar/domain/symbols/AttendanceCodeSymbol.ts
@@ -1,0 +1,7 @@
+export const ATTENDANCE_CODE_REPOSITORY = Symbol('AttendanceCodeRepository');
+export const ATTENDANCE_CODE_SERVICE = Symbol('AttendanceCodeService');
+export const ATTENDANCE_CODE_LIST_USE_CASE = Symbol('ListAttendanceCodeUseCase');
+export const ATTENDANCE_CODE_CREATE_USE_CASE = Symbol('CreateAttendanceCodeUseCase');
+export const ATTENDANCE_CODE_UPDATE_USE_CASE = Symbol('UpdateAttendanceCodeUseCase');
+export const ATTENDANCE_CODE_DELETE_USE_CASE = Symbol('DeleteAttendanceCodeUseCase');
+export const ATTENDANCE_CODE_GET_USE_CASE = Symbol('GetAttendanceCodeUseCase');

--- a/src/scolar/domain/symbols/BehaviorScaleSymbol.ts
+++ b/src/scolar/domain/symbols/BehaviorScaleSymbol.ts
@@ -1,0 +1,7 @@
+export const BEHAVIOR_SCALE_REPOSITORY = Symbol('BehaviorScaleRepository');
+export const BEHAVIOR_SCALE_SERVICE = Symbol('BehaviorScaleService');
+export const BEHAVIOR_SCALE_LIST_USE_CASE = Symbol('ListBehaviorScaleUseCase');
+export const BEHAVIOR_SCALE_CREATE_USE_CASE = Symbol('CreateBehaviorScaleUseCase');
+export const BEHAVIOR_SCALE_UPDATE_USE_CASE = Symbol('UpdateBehaviorScaleUseCase');
+export const BEHAVIOR_SCALE_DELETE_USE_CASE = Symbol('DeleteBehaviorScaleUseCase');
+export const BEHAVIOR_SCALE_GET_USE_CASE = Symbol('GetBehaviorScaleUseCase');

--- a/src/scolar/domain/symbols/ClassScheduleSymbol.ts
+++ b/src/scolar/domain/symbols/ClassScheduleSymbol.ts
@@ -1,0 +1,7 @@
+export const CLASS_SCHEDULE_REPOSITORY = Symbol('ClassScheduleRepository');
+export const CLASS_SCHEDULE_SERVICE = Symbol('ClassScheduleService');
+export const CLASS_SCHEDULE_LIST_USE_CASE = Symbol('ListClassScheduleUseCase');
+export const CLASS_SCHEDULE_CREATE_USE_CASE = Symbol('CreateClassScheduleUseCase');
+export const CLASS_SCHEDULE_UPDATE_USE_CASE = Symbol('UpdateClassScheduleUseCase');
+export const CLASS_SCHEDULE_DELETE_USE_CASE = Symbol('DeleteClassScheduleUseCase');
+export const CLASS_SCHEDULE_GET_USE_CASE = Symbol('GetClassScheduleUseCase');

--- a/src/scolar/domain/symbols/MeetingTypeSymbol.ts
+++ b/src/scolar/domain/symbols/MeetingTypeSymbol.ts
@@ -1,0 +1,7 @@
+export const MEETING_TYPE_REPOSITORY = Symbol('MeetingTypeRepository');
+export const MEETING_TYPE_SERVICE = Symbol('MeetingTypeService');
+export const MEETING_TYPE_LIST_USE_CASE = Symbol('ListMeetingTypeUseCase');
+export const MEETING_TYPE_CREATE_USE_CASE = Symbol('CreateMeetingTypeUseCase');
+export const MEETING_TYPE_UPDATE_USE_CASE = Symbol('UpdateMeetingTypeUseCase');
+export const MEETING_TYPE_DELETE_USE_CASE = Symbol('DeleteMeetingTypeUseCase');
+export const MEETING_TYPE_GET_USE_CASE = Symbol('GetMeetingTypeUseCase');

--- a/src/scolar/infrastructure/adapters/api/AcademicPlanningRepositoryImpl.ts
+++ b/src/scolar/infrastructure/adapters/api/AcademicPlanningRepositoryImpl.ts
@@ -1,0 +1,32 @@
+import { AxiosInstance } from "axios";
+import { injectable } from "inversify";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { AcademicPlanningDto } from "../../dto/AcademicPlanningDto";
+import { AcademicPlanningRepository } from "@/scolar/domain/repositories/AcademicPlanningRepository";
+
+@injectable()
+export class AcademicPlanningRepositoryImpl implements AcademicPlanningRepository {
+    constructor(private readonly http: AxiosInstance) {}
+
+    async findAll(page: number, limit: number, search?: string, orderby?: string[]): Promise<PaginatedResult<AcademicPlanningDto>> {
+        const { data } = await this.http.get<PaginatedResult<AcademicPlanningDto>>("/academic-plannings/", {
+            params: { page, limit, search, orderby },
+        });
+        return data;
+    }
+    async findById(id: number): Promise<AcademicPlanningDto> {
+        const { data } = await this.http.get<AcademicPlanningDto>(`/academic-plannings/${id}`);
+        return data;
+    }
+    async create(entity: Omit<AcademicPlanningDto, 'id'>): Promise<AcademicPlanningDto> {
+        const { data } = await this.http.post<AcademicPlanningDto>("/academic-plannings/", entity);
+        return data;
+    }
+    async update(id: number, entity: Omit<AcademicPlanningDto, 'id'>): Promise<AcademicPlanningDto> {
+        const { data } = await this.http.put<AcademicPlanningDto>(`/academic-plannings/${id}`, entity);
+        return data;
+    }
+    async delete(id: number): Promise<void> {
+        await this.http.delete(`/academic-plannings/${id}`);
+    }
+}

--- a/src/scolar/infrastructure/adapters/api/AttendanceCodeRepositoryImpl.ts
+++ b/src/scolar/infrastructure/adapters/api/AttendanceCodeRepositoryImpl.ts
@@ -1,0 +1,32 @@
+import { AxiosInstance } from "axios";
+import { injectable } from "inversify";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { AttendanceCodeDto } from "../../dto/AttendanceCodeDto";
+import { AttendanceCodeRepository } from "@/scolar/domain/repositories/AttendanceCodeRepository";
+
+@injectable()
+export class AttendanceCodeRepositoryImpl implements AttendanceCodeRepository {
+    constructor(private readonly http: AxiosInstance) {}
+
+    async findAll(page: number, limit: number, search?: string, orderby?: string[]): Promise<PaginatedResult<AttendanceCodeDto>> {
+        const { data } = await this.http.get<PaginatedResult<AttendanceCodeDto>>("/attendance-codes/", {
+            params: { page, limit, search, orderby },
+        });
+        return data;
+    }
+    async findById(id: number): Promise<AttendanceCodeDto> {
+        const { data } = await this.http.get<AttendanceCodeDto>(`/attendance-codes/${id}`);
+        return data;
+    }
+    async create(entity: Omit<AttendanceCodeDto, 'id'>): Promise<AttendanceCodeDto> {
+        const { data } = await this.http.post<AttendanceCodeDto>("/attendance-codes/", entity);
+        return data;
+    }
+    async update(id: number, entity: Omit<AttendanceCodeDto, 'id'>): Promise<AttendanceCodeDto> {
+        const { data } = await this.http.put<AttendanceCodeDto>(`/attendance-codes/${id}`, entity);
+        return data;
+    }
+    async delete(id: number): Promise<void> {
+        await this.http.delete(`/attendance-codes/${id}`);
+    }
+}

--- a/src/scolar/infrastructure/adapters/api/BehaviorScaleRepositoryImpl.ts
+++ b/src/scolar/infrastructure/adapters/api/BehaviorScaleRepositoryImpl.ts
@@ -1,0 +1,32 @@
+import { AxiosInstance } from "axios";
+import { injectable } from "inversify";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { BehaviorScaleDto } from "../../dto/BehaviorScaleDto";
+import { BehaviorScaleRepository } from "@/scolar/domain/repositories/BehaviorScaleRepository";
+
+@injectable()
+export class BehaviorScaleRepositoryImpl implements BehaviorScaleRepository {
+    constructor(private readonly http: AxiosInstance) {}
+
+    async findAll(page: number, limit: number, search?: string, orderby?: string[]): Promise<PaginatedResult<BehaviorScaleDto>> {
+        const { data } = await this.http.get<PaginatedResult<BehaviorScaleDto>>("/behavior-scales/", {
+            params: { page, limit, search, orderby },
+        });
+        return data;
+    }
+    async findById(id: number): Promise<BehaviorScaleDto> {
+        const { data } = await this.http.get<BehaviorScaleDto>(`/behavior-scales/${id}`);
+        return data;
+    }
+    async create(entity: Omit<BehaviorScaleDto, 'id'>): Promise<BehaviorScaleDto> {
+        const { data } = await this.http.post<BehaviorScaleDto>("/behavior-scales/", entity);
+        return data;
+    }
+    async update(id: number, entity: Omit<BehaviorScaleDto, 'id'>): Promise<BehaviorScaleDto> {
+        const { data } = await this.http.put<BehaviorScaleDto>(`/behavior-scales/${id}`, entity);
+        return data;
+    }
+    async delete(id: number): Promise<void> {
+        await this.http.delete(`/behavior-scales/${id}`);
+    }
+}

--- a/src/scolar/infrastructure/adapters/api/ClassScheduleRepositoryImpl.ts
+++ b/src/scolar/infrastructure/adapters/api/ClassScheduleRepositoryImpl.ts
@@ -1,0 +1,32 @@
+import { AxiosInstance } from "axios";
+import { injectable } from "inversify";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { ClassScheduleDto } from "../../dto/ClassScheduleDto";
+import { ClassScheduleRepository } from "@/scolar/domain/repositories/ClassScheduleRepository";
+
+@injectable()
+export class ClassScheduleRepositoryImpl implements ClassScheduleRepository {
+    constructor(private readonly http: AxiosInstance) {}
+
+    async findAll(page: number, limit: number, search?: string, orderby?: string[]): Promise<PaginatedResult<ClassScheduleDto>> {
+        const { data } = await this.http.get<PaginatedResult<ClassScheduleDto>>("/class-schedules/", {
+            params: { page, limit, search, orderby },
+        });
+        return data;
+    }
+    async findById(id: number): Promise<ClassScheduleDto> {
+        const { data } = await this.http.get<ClassScheduleDto>(`/class-schedules/${id}`);
+        return data;
+    }
+    async create(entity: Omit<ClassScheduleDto, 'id'>): Promise<ClassScheduleDto> {
+        const { data } = await this.http.post<ClassScheduleDto>("/class-schedules/", entity);
+        return data;
+    }
+    async update(id: number, entity: Omit<ClassScheduleDto, 'id'>): Promise<ClassScheduleDto> {
+        const { data } = await this.http.put<ClassScheduleDto>(`/class-schedules/${id}`, entity);
+        return data;
+    }
+    async delete(id: number): Promise<void> {
+        await this.http.delete(`/class-schedules/${id}`);
+    }
+}

--- a/src/scolar/infrastructure/adapters/api/MeetingTypeRepositoryImpl.ts
+++ b/src/scolar/infrastructure/adapters/api/MeetingTypeRepositoryImpl.ts
@@ -1,0 +1,32 @@
+import { AxiosInstance } from "axios";
+import { injectable } from "inversify";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { MeetingTypeDto } from "../../dto/MeetingTypeDto";
+import { MeetingTypeRepository } from "@/scolar/domain/repositories/MeetingTypeRepository";
+
+@injectable()
+export class MeetingTypeRepositoryImpl implements MeetingTypeRepository {
+    constructor(private readonly http: AxiosInstance) {}
+
+    async findAll(page: number, limit: number, search?: string, orderby?: string[]): Promise<PaginatedResult<MeetingTypeDto>> {
+        const { data } = await this.http.get<PaginatedResult<MeetingTypeDto>>("/meeting-types/", {
+            params: { page, limit, search, orderby },
+        });
+        return data;
+    }
+    async findById(id: number): Promise<MeetingTypeDto> {
+        const { data } = await this.http.get<MeetingTypeDto>(`/meeting-types/${id}`);
+        return data;
+    }
+    async create(entity: Omit<MeetingTypeDto, 'id'>): Promise<MeetingTypeDto> {
+        const { data } = await this.http.post<MeetingTypeDto>("/meeting-types/", entity);
+        return data;
+    }
+    async update(id: number, entity: Omit<MeetingTypeDto, 'id'>): Promise<MeetingTypeDto> {
+        const { data } = await this.http.put<MeetingTypeDto>(`/meeting-types/${id}`, entity);
+        return data;
+    }
+    async delete(id: number): Promise<void> {
+        await this.http.delete(`/meeting-types/${id}`);
+    }
+}

--- a/src/scolar/infrastructure/dto/AcademicPlanningDto.ts
+++ b/src/scolar/infrastructure/dto/AcademicPlanningDto.ts
@@ -1,0 +1,11 @@
+export interface AcademicPlanningDto {
+    id: number;
+    course_id: number;
+    parallel_id: number;
+    school_year_id: number;
+    subject_id: number;
+    topic: string;
+    start_date: string;
+    end_date: string;
+    description: string;
+}

--- a/src/scolar/infrastructure/dto/AttendanceCodeDto.ts
+++ b/src/scolar/infrastructure/dto/AttendanceCodeDto.ts
@@ -1,0 +1,6 @@
+export interface AttendanceCodeDto {
+    id: number;
+    code: string;
+    description: string;
+    affectsGrade: boolean;
+}

--- a/src/scolar/infrastructure/dto/BehaviorScaleDto.ts
+++ b/src/scolar/infrastructure/dto/BehaviorScaleDto.ts
@@ -1,0 +1,6 @@
+export interface BehaviorScaleDto {
+    id: number;
+    name: string;
+    minScore: string;
+    maxScore: string;
+}

--- a/src/scolar/infrastructure/dto/ClassScheduleDto.ts
+++ b/src/scolar/infrastructure/dto/ClassScheduleDto.ts
@@ -1,0 +1,10 @@
+export interface ClassScheduleDto {
+    id: number;
+    course_id: number;
+    parallel_id: number;
+    school_year_id: number;
+    subject_id: number;
+    day_of_week: string;
+    start_time: string;
+    end_time: string;
+}

--- a/src/scolar/infrastructure/dto/MeetingTypeDto.ts
+++ b/src/scolar/infrastructure/dto/MeetingTypeDto.ts
@@ -1,0 +1,5 @@
+export interface MeetingTypeDto {
+    id: number;
+    name: string;
+    description: string;
+}

--- a/src/scolar/presentation/ui/AcademicPlanning/Create/AcademicPlanningCreateContainer.tsx
+++ b/src/scolar/presentation/ui/AcademicPlanning/Create/AcademicPlanningCreateContainer.tsx
@@ -1,0 +1,38 @@
+import { useInjection } from "inversify-react";
+import { AcademicPlanningCreatePresenter } from "./AcademicPlanningCreatePresenter";
+import { CreateAcademicPlanningCommand, CreateAcademicPlanningUseCase } from "@/scolar/application/useCases/academicPlannings/createAcademicPlanningUseCase";
+import { ACADEMIC_PLANNING_CREATE_USE_CASE } from "@/scolar/domain/symbols/AcademicPlanningSymbol";
+import { useForm } from "react-hook-form";
+import { toast } from "@/hooks/use-toast";
+import { useTransition } from "react";
+import { useNavigate } from "react-router-dom";
+
+export const AcademicPlanningCreateContainer = () => {
+    const usecase = useInjection<CreateAcademicPlanningUseCase>(ACADEMIC_PLANNING_CREATE_USE_CASE);
+    const [isPending, startTransition] = useTransition();
+    const { register, handleSubmit, formState: { errors } } = useForm<CreateAcademicPlanningCommand>({
+        defaultValues: { data: { id: 0, courseId: 0, parallelId: 0, schoolYearId: 0, subjectId: 0, topic: '', startDate: '', endDate: '', description: '' } }
+    });
+    const navigate = useNavigate();
+    const onSubmit = (data: CreateAcademicPlanningCommand) => {
+        startTransition(async () => {
+            const res = await usecase.execute(new CreateAcademicPlanningCommand(data.data));
+            if (res.isLeft()) {
+                toast({ title: 'Error', description: 'No se pudo crear', variant: 'destructive' });
+                return;
+            }
+            toast({ title: 'Planificación creada', description: 'Planificación creada correctamente', variant: 'success' });
+            navigate('/planificaciones-academicas');
+        });
+    };
+    const onCancel = () => navigate('/planificaciones-academicas');
+    return (
+        <AcademicPlanningCreatePresenter
+            onSubmit={handleSubmit(onSubmit)}
+            onCancel={onCancel}
+            register={register}
+            errors={errors}
+            isSubmitting={isPending}
+        />
+    );
+};

--- a/src/scolar/presentation/ui/AcademicPlanning/Create/AcademicPlanningCreatePresenter.tsx
+++ b/src/scolar/presentation/ui/AcademicPlanning/Create/AcademicPlanningCreatePresenter.tsx
@@ -1,0 +1,74 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+import { CreateAcademicPlanningCommand } from "@/scolar/application/useCases/academicPlannings/createAcademicPlanningUseCase";
+
+interface Props {
+    onSubmit: () => void;
+    onCancel: () => void;
+    register: UseFormRegister<CreateAcademicPlanningCommand>;
+    errors: FieldErrors<CreateAcademicPlanningCommand>;
+    isSubmitting: boolean;
+}
+
+export const AcademicPlanningCreatePresenter = ({ onSubmit, onCancel, register, errors, isSubmitting }: Props) => {
+    return (
+        <Card>
+            <form onSubmit={onSubmit}>
+                <CardHeader>
+                    <CardTitle>Crear Planificación Académica</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                    <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                            <Label htmlFor="courseId">Curso ID</Label>
+                            <Input id="courseId" type="number" {...register("data.courseId", { valueAsNumber: true, required: true })} />
+                            {errors.data?.courseId && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="parallelId">Paralelo ID</Label>
+                            <Input id="parallelId" type="number" {...register("data.parallelId", { valueAsNumber: true, required: true })} />
+                            {errors.data?.parallelId && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="schoolYearId">Periodo Lectivo ID</Label>
+                            <Input id="schoolYearId" type="number" {...register("data.schoolYearId", { valueAsNumber: true, required: true })} />
+                            {errors.data?.schoolYearId && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="subjectId">Materia ID</Label>
+                            <Input id="subjectId" type="number" {...register("data.subjectId", { valueAsNumber: true, required: true })} />
+                            {errors.data?.subjectId && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2 col-span-2">
+                            <Label htmlFor="topic">Tema</Label>
+                            <Input id="topic" {...register("data.topic", { required: true })} />
+                            {errors.data?.topic && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="startDate">Fecha inicio</Label>
+                            <Input id="startDate" type="date" {...register("data.startDate", { required: true })} />
+                            {errors.data?.startDate && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="endDate">Fecha fin</Label>
+                            <Input id="endDate" type="date" {...register("data.endDate", { required: true })} />
+                            {errors.data?.endDate && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2 col-span-2">
+                            <Label htmlFor="description">Descripción</Label>
+                            <Textarea id="description" {...register("data.description")} />
+                        </div>
+                    </div>
+                </CardContent>
+                <CardFooter className="flex justify-between">
+                    <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>Cancelar</Button>
+                    <Button type="submit" disabled={isSubmitting}>{isSubmitting ? 'Guardando...' : 'Guardar'}</Button>
+                </CardFooter>
+            </form>
+        </Card>
+    );
+};

--- a/src/scolar/presentation/ui/AcademicPlanning/Delete/DeleteAcademicPlanningContainer.tsx
+++ b/src/scolar/presentation/ui/AcademicPlanning/Delete/DeleteAcademicPlanningContainer.tsx
@@ -1,0 +1,33 @@
+import { toast } from "@/hooks/use-toast";
+import { useInjection } from "inversify-react";
+import { DeleteAcademicPlanningPresenter } from "./DeleteAcademicPlanningPresenter";
+import { AcademicPlanning } from "@/scolar/domain/entities/academicPlanning";
+import { DeleteAcademicPlanningCommand, DeleteAcademicPlanningUseCase } from "@/scolar/application/useCases/academicPlannings/deleteAcademicPlanningUseCase";
+import { ACADEMIC_PLANNING_DELETE_USE_CASE } from "@/scolar/domain/symbols/AcademicPlanningSymbol";
+
+interface Props {
+    planning: AcademicPlanning;
+    onConfirm: () => void;
+}
+
+export const DeleteAcademicPlanningContainer = ({ planning, onConfirm }: Props) => {
+    const usecase = useInjection<DeleteAcademicPlanningUseCase>(ACADEMIC_PLANNING_DELETE_USE_CASE);
+    const handleDelete = async () => {
+        const res = await usecase.execute(new DeleteAcademicPlanningCommand(planning.id));
+        if (res.isRight()) {
+            toast({
+                title: "Planificación eliminada",
+                description: "La planificación ha sido eliminada correctamente",
+                variant: "success",
+            });
+            onConfirm();
+        } else {
+            toast({
+                title: "Error eliminando",
+                description: "No se pudo eliminar la planificación",
+                variant: "destructive",
+            });
+        }
+    };
+    return <DeleteAcademicPlanningPresenter planning={planning} onConfirm={handleDelete} />;
+};

--- a/src/scolar/presentation/ui/AcademicPlanning/Delete/DeleteAcademicPlanningPresenter.tsx
+++ b/src/scolar/presentation/ui/AcademicPlanning/Delete/DeleteAcademicPlanningPresenter.tsx
@@ -1,0 +1,42 @@
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { AcademicPlanning } from "@/scolar/domain/entities/academicPlanning";
+import { Trash2 } from "lucide-react";
+
+interface Props {
+    planning: AcademicPlanning;
+    onConfirm: () => void;
+}
+
+export const DeleteAcademicPlanningPresenter = ({ planning, onConfirm }: Props) => {
+    return (
+        <Dialog>
+            <DialogTrigger asChild>
+                <Button variant="ghost" size="icon">
+                    <Trash2 className="h-4 w-4" />
+                    <span className="sr-only">Eliminar</span>
+                </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle>¿Eliminar planificación?</DialogTitle>
+                    <DialogDescription>
+                        Esta acción no se puede deshacer.
+                        <br />
+                        <strong>{planning.topic}</strong>
+                    </DialogDescription>
+                </DialogHeader>
+                <DialogFooter className="sm:justify-start">
+                    <DialogClose asChild>
+                        <Button type="button" variant="destructive" onClick={onConfirm}>
+                            Confirmar
+                        </Button>
+                    </DialogClose>
+                    <Button type="button" variant="outline">
+                        Cancelar
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};

--- a/src/scolar/presentation/ui/AcademicPlanning/Edit/AcademicPlanningEditContainer.tsx
+++ b/src/scolar/presentation/ui/AcademicPlanning/Edit/AcademicPlanningEditContainer.tsx
@@ -1,0 +1,58 @@
+import { startTransition, useCallback, useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { useInjection } from "inversify-react";
+import { toast } from "@/hooks/use-toast";
+import { useNavigate, useParams } from "react-router-dom";
+import { AcademicPlanning } from "@/scolar/domain/entities/academicPlanning";
+import { GetAcademicPlanningUseCase, GetAcademicPlanningCommand } from "@/scolar/application/useCases/academicPlannings/getAcademicPlanningUseCase";
+import { UpdateAcademicPlanningUseCase, UpdateAcademicPlanningCommand } from "@/scolar/application/useCases/academicPlannings/updateAcademicPlanningUseCase";
+import { ACADEMIC_PLANNING_GET_USE_CASE, ACADEMIC_PLANNING_UPDATE_USE_CASE } from "@/scolar/domain/symbols/AcademicPlanningSymbol";
+import { AcademicPlanningEditPresenter } from "./AcademicPlanningEditPresenter";
+
+export const AcademicPlanningEditContainer = () => {
+    const { id } = useParams<{ id: string }>();
+    const getUseCase = useInjection<GetAcademicPlanningUseCase>(ACADEMIC_PLANNING_GET_USE_CASE);
+    const updateUseCase = useInjection<UpdateAcademicPlanningUseCase>(ACADEMIC_PLANNING_UPDATE_USE_CASE);
+    const { register, handleSubmit, formState: { errors }, setValue, watch } = useForm<UpdateAcademicPlanningCommand>({
+        defaultValues: { data: { id: Number(id), courseId: 0, parallelId: 0, schoolYearId: 0, subjectId: 0, topic: '', startDate: '', endDate: '', description: '' } }
+    });
+    const data = watch();
+
+    const load = useCallback(() => {
+        startTransition(() => {
+            getUseCase.execute(new GetAcademicPlanningCommand(Number(id))).then(res => {
+                if (res.isLeft()) {
+                    toast({ title: 'Error', description: 'No encontrado', variant: 'destructive' });
+                    return;
+                }
+                const m = res.extract() as AcademicPlanning;
+                setValue('data.id', m.id);
+                setValue('data.courseId', m.courseId);
+                setValue('data.parallelId', m.parallelId);
+                setValue('data.schoolYearId', m.schoolYearId);
+                setValue('data.subjectId', m.subjectId);
+                setValue('data.topic', m.topic);
+                setValue('data.startDate', m.startDate);
+                setValue('data.endDate', m.endDate);
+                setValue('data.description', m.description);
+            });
+        });
+    }, [getUseCase, id, setValue]);
+
+    useEffect(() => { load(); }, [load]);
+
+    const onSubmit = () => {
+        startTransition(() => {
+            updateUseCase.execute(new UpdateAcademicPlanningCommand(data.data)).then(res => {
+                if (res.isLeft()) {
+                    toast({ title: 'Error', description: 'No se pudo actualizar', variant: 'destructive' });
+                    return;
+                }
+                toast({ title: 'Actualizado', description: 'Planificación actualizada' });
+            });
+        });
+    };
+    const navigate = useNavigate();
+    const onCancel = () => navigate('/planificaciones-academicas');
+    return <AcademicPlanningEditPresenter onSubmit={handleSubmit(onSubmit)} onCancel={onCancel} register={register} errors={errors} isSubmitting={false} />;
+};

--- a/src/scolar/presentation/ui/AcademicPlanning/Edit/AcademicPlanningEditPresenter.tsx
+++ b/src/scolar/presentation/ui/AcademicPlanning/Edit/AcademicPlanningEditPresenter.tsx
@@ -1,0 +1,74 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+import { UpdateAcademicPlanningCommand } from "@/scolar/application/useCases/academicPlannings/updateAcademicPlanningUseCase";
+
+interface Props {
+    onSubmit: () => void;
+    onCancel: () => void;
+    register: UseFormRegister<UpdateAcademicPlanningCommand>;
+    errors: FieldErrors<UpdateAcademicPlanningCommand>;
+    isSubmitting: boolean;
+}
+
+export const AcademicPlanningEditPresenter = ({ onSubmit, onCancel, register, errors, isSubmitting }: Props) => {
+    return (
+        <Card>
+            <form onSubmit={onSubmit}>
+                <CardHeader>
+                    <CardTitle>Editar Planificación Académica</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                    <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                            <Label htmlFor="courseId">Curso ID</Label>
+                            <Input id="courseId" type="number" {...register("data.courseId", { valueAsNumber: true, required: true })} />
+                            {errors.data?.courseId && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="parallelId">Paralelo ID</Label>
+                            <Input id="parallelId" type="number" {...register("data.parallelId", { valueAsNumber: true, required: true })} />
+                            {errors.data?.parallelId && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="schoolYearId">Periodo Lectivo ID</Label>
+                            <Input id="schoolYearId" type="number" {...register("data.schoolYearId", { valueAsNumber: true, required: true })} />
+                            {errors.data?.schoolYearId && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="subjectId">Materia ID</Label>
+                            <Input id="subjectId" type="number" {...register("data.subjectId", { valueAsNumber: true, required: true })} />
+                            {errors.data?.subjectId && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2 col-span-2">
+                            <Label htmlFor="topic">Tema</Label>
+                            <Input id="topic" {...register("data.topic", { required: true })} />
+                            {errors.data?.topic && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="startDate">Fecha inicio</Label>
+                            <Input id="startDate" type="date" {...register("data.startDate", { required: true })} />
+                            {errors.data?.startDate && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="endDate">Fecha fin</Label>
+                            <Input id="endDate" type="date" {...register("data.endDate", { required: true })} />
+                            {errors.data?.endDate && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2 col-span-2">
+                            <Label htmlFor="description">Descripción</Label>
+                            <Textarea id="description" {...register("data.description")} />
+                        </div>
+                    </div>
+                </CardContent>
+                <CardFooter className="flex justify-between">
+                    <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>Cancelar</Button>
+                    <Button type="submit" disabled={isSubmitting}>{isSubmitting ? 'Guardando...' : 'Guardar'}</Button>
+                </CardFooter>
+            </form>
+        </Card>
+    );
+};

--- a/src/scolar/presentation/ui/AcademicPlanning/List/AcademicPlanningListContainer.tsx
+++ b/src/scolar/presentation/ui/AcademicPlanning/List/AcademicPlanningListContainer.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useRef, useState, useTransition } from "react";
+import { useInjection } from "inversify-react";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { AcademicPlanning } from "@/scolar/domain/entities/academicPlanning";
+import { toast } from "@/hooks/use-toast";
+import { ListAcademicPlanningsUseCase, ListAcademicPlanningsCommand } from "@/scolar/application/useCases/academicPlannings/listAcademicPlanningsUseCase";
+import { ACADEMIC_PLANNING_LIST_USE_CASE } from "@/scolar/domain/symbols/AcademicPlanningSymbol";
+import { AcademicPlanningListPresenter } from "./AcademicPlanningListPresenter";
+import { useNavigate } from "react-router-dom";
+
+export const AcademicPlanningListContainer = () => {
+    const listUseCase = useInjection<ListAcademicPlanningsUseCase>(ACADEMIC_PLANNING_LIST_USE_CASE);
+    const [isPending, startTransition] = useTransition();
+    const [command, setCommand] = useState({ page: 1, perPage: 10, where: '', orderBy: [] as string[] });
+    const [result, setResult] = useState<PaginatedResult<AcademicPlanning>>({
+        data: [],
+        meta: { currentPage: 1, lastPage: 1, next: null, perPage: 10, prev: null, total: 0 }
+    });
+    const debounceRef = useRef<NodeJS.Timeout | null>(null);
+
+    useEffect(() => {
+        handleLoad();
+    }, [command]);
+
+    const handleLoad = () => {
+        startTransition(() => {
+            listUseCase.execute(new ListAcademicPlanningsCommand(command.page, command.perPage, command.orderBy, command.where)).then(res => {
+                if (res.isRight()) {
+                    setResult(res.extract() as PaginatedResult<AcademicPlanning>);
+                } else {
+                    toast({ title: 'Error', description: 'Error al cargar', variant: 'destructive' });
+                }
+            });
+        });
+    };
+
+    const navigate = useNavigate();
+    const handleAdd = () => navigate('/planificaciones-academicas/nuevo');
+    const handleEdit = (m: AcademicPlanning) => navigate(`/planificaciones-academicas/${m.id}`);
+    const handlePaginate = (page: number) => setCommand({ ...command, page });
+    const handleSearch = (term: string) => {
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        debounceRef.current = setTimeout(() => setCommand({ ...command, where: term }), 300);
+    };
+
+    return (
+        <AcademicPlanningListPresenter
+            plannings={result}
+            onAdd={handleAdd}
+            onEdit={handleEdit}
+            onDelete={() => handleLoad()}
+            onPaginate={handlePaginate}
+            isPending={isPending}
+            onSearch={handleSearch}
+        />
+    );
+};

--- a/src/scolar/presentation/ui/AcademicPlanning/List/AcademicPlanningListPresenter.tsx
+++ b/src/scolar/presentation/ui/AcademicPlanning/List/AcademicPlanningListPresenter.tsx
@@ -1,0 +1,97 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Pagination, PaginationContent, PaginationItem, PaginationLink, PaginationNext, PaginationPrevious } from "@/components/ui/pagination";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Input } from "@/components/ui/input";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { AcademicPlanning } from "@/scolar/domain/entities/academicPlanning";
+import { Edit, Plus, Search } from "lucide-react";
+import { DeleteAcademicPlanningContainer } from "../Delete/DeleteAcademicPlanningContainer";
+
+interface Props {
+    plannings: PaginatedResult<AcademicPlanning>;
+    onEdit: (m: AcademicPlanning) => void;
+    onDelete: (id: number) => void;
+    onAdd: () => void;
+    onPaginate: (page: number) => void;
+    isPending?: boolean;
+    onSearch: (term: string) => void;
+}
+
+export const AcademicPlanningListPresenter = ({ plannings, onEdit, onDelete, onAdd, onPaginate, isPending, onSearch }: Props) => {
+    return (
+        <Card>
+            <CardHeader className="flex flex-row items-center justify-between">
+                <CardTitle>Planificaciones Académicas</CardTitle>
+                <Button onClick={onAdd} size="sm">
+                    <Plus className="h-4 w-4 mr-2" /> Nuevo
+                </Button>
+            </CardHeader>
+            <CardContent>
+                <div className="relative flex-1 mb-4">
+                    <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+                    <Input type="search" placeholder="Buscar..." className="pl-9" onChange={(e) => onSearch(e.target.value)} />
+                </div>
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead>Curso</TableHead>
+                            <TableHead>Paralelo</TableHead>
+                            <TableHead>Tema</TableHead>
+                            <TableHead>Inicio</TableHead>
+                            <TableHead>Fin</TableHead>
+                            <TableHead className="text-right">Acciones</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {isPending && (
+                            <TableRow>
+                                {Array.from({ length: 6 }).map((_, i) => (
+                                    <TableCell key={i}><Skeleton className="h-4 w-full" /></TableCell>
+                                ))}
+                            </TableRow>
+                        )}
+                        {plannings.data.map((m) => (
+                            <TableRow key={m.id}>
+                                <TableCell className="font-medium">{m.courseId}</TableCell>
+                                <TableCell>{m.parallelId}</TableCell>
+                                <TableCell>{m.topic}</TableCell>
+                                <TableCell>{m.startDate}</TableCell>
+                                <TableCell>{m.endDate}</TableCell>
+                                <TableCell className="text-right">
+                                    <div className="flex justify-end gap-2">
+                                        <Button variant="ghost" size="icon" onClick={() => onEdit(m)}>
+                                            <Edit className="h-4 w-4" />
+                                            <span className="sr-only">Editar</span>
+                                        </Button>
+                                        <DeleteAcademicPlanningContainer planning={m} onConfirm={() => onDelete(m.id)} />
+                                    </div>
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+                <div className="mt-4 flex justify-end items-center gap-4">
+                    <Pagination>
+                        <PaginationContent>
+                            <PaginationItem>
+                                <PaginationPrevious href="#" className={plannings.meta.prev ? 'cursor-pointer' : 'cursor-not-allowed'} onClick={() => onPaginate(plannings.meta.currentPage - 1)} />
+                            </PaginationItem>
+                            {Array.from({ length: plannings.meta.lastPage }, (_, i) => i + 1).map((page) => (
+                                <PaginationItem key={page}>
+                                    <PaginationLink href="#" isActive={page === plannings.meta.currentPage} onClick={() => onPaginate(page)}>
+                                        {page}
+                                    </PaginationLink>
+                                </PaginationItem>
+                            ))}
+                            <PaginationItem>
+                                <PaginationNext href="#" className={plannings.meta.next ? 'cursor-pointer' : 'cursor-not-allowed'} onClick={() => onPaginate(plannings.meta.currentPage + 1)} />
+                            </PaginationItem>
+                        </PaginationContent>
+                    </Pagination>
+                </div>
+            </CardContent>
+        </Card>
+    );
+};

--- a/src/scolar/presentation/ui/AttendanceCode/Create/AttendanceCodeCreateContainer.tsx
+++ b/src/scolar/presentation/ui/AttendanceCode/Create/AttendanceCodeCreateContainer.tsx
@@ -1,0 +1,38 @@
+import { useInjection } from "inversify-react";
+import { AttendanceCodeCreatePresenter } from "./AttendanceCodeCreatePresenter";
+import { CreateAttendanceCodeCommand, CreateAttendanceCodeUseCase } from "@/scolar/application/useCases/attendanceCodes/createAttendanceCodeUseCase";
+import { ATTENDANCE_CODE_CREATE_USE_CASE } from "@/scolar/domain/symbols/AttendanceCodeSymbol";
+import { useForm } from "react-hook-form";
+import { toast } from "@/hooks/use-toast";
+import { useTransition } from "react";
+import { useNavigate } from "react-router-dom";
+
+export const AttendanceCodeCreateContainer = () => {
+    const usecase = useInjection<CreateAttendanceCodeUseCase>(ATTENDANCE_CODE_CREATE_USE_CASE);
+    const [isPending, startTransition] = useTransition();
+    const { register, handleSubmit, formState: { errors } } = useForm<CreateAttendanceCodeCommand>({
+        defaultValues: { data: { id: 0, code: '', description: '', affectsGrade: false } }
+    });
+    const onSubmit = (data: CreateAttendanceCodeCommand) => {
+        startTransition(async () => {
+            const res = await usecase.execute(new CreateAttendanceCodeCommand(data.data));
+            if (res.isLeft()) {
+                toast({ title: 'Error', description: 'No se pudo crear', variant: 'destructive' });
+                return;
+            }
+            toast({ title: 'Código creado', description: `Código ${data.data.code} creado`, variant: 'success' });
+            navigate('/codigos-asistencia');
+        });
+    };
+    const navigate = useNavigate();
+    const onCancel = () => navigate('/codigos-asistencia');
+    return (
+        <AttendanceCodeCreatePresenter
+            onSubmit={handleSubmit(onSubmit)}
+            onCancel={onCancel}
+            register={register}
+            errors={errors}
+            isSubmitting={isPending}
+        />
+    );
+};

--- a/src/scolar/presentation/ui/AttendanceCode/Create/AttendanceCodeCreatePresenter.tsx
+++ b/src/scolar/presentation/ui/AttendanceCode/Create/AttendanceCodeCreatePresenter.tsx
@@ -1,0 +1,45 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Checkbox } from "@/components/ui/checkbox";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+import { CreateAttendanceCodeCommand } from "@/scolar/application/useCases/attendanceCodes/createAttendanceCodeUseCase";
+
+interface Props {
+    onSubmit: () => void;
+    onCancel: () => void;
+    register: UseFormRegister<CreateAttendanceCodeCommand>;
+    errors: FieldErrors<CreateAttendanceCodeCommand>;
+    isSubmitting: boolean;
+}
+
+export const AttendanceCodeCreatePresenter = ({ onSubmit, onCancel, register, errors, isSubmitting }: Props) => (
+    <Card>
+        <form onSubmit={onSubmit}>
+            <CardHeader>
+                <CardTitle>Crear Código de Asistencia</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                <div className="space-y-2">
+                    <Label htmlFor="code">Código</Label>
+                    <Input id="code" {...register("data.code", { required: true })} />
+                    {errors.data?.code && <p className="text-red-500 text-sm">Requerido</p>}
+                </div>
+                <div className="space-y-2">
+                    <Label htmlFor="description">Descripción</Label>
+                    <Textarea id="description" {...register("data.description")}></Textarea>
+                </div>
+                <div className="flex items-center space-x-2">
+                    <Checkbox id="affectsGrade" {...register("data.affectsGrade")} />
+                    <Label htmlFor="affectsGrade">Afecta la calificación</Label>
+                </div>
+            </CardContent>
+            <CardFooter className="flex justify-between">
+                <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>Cancelar</Button>
+                <Button type="submit" disabled={isSubmitting}>{isSubmitting ? 'Guardando...' : 'Guardar'}</Button>
+            </CardFooter>
+        </form>
+    </Card>
+);

--- a/src/scolar/presentation/ui/AttendanceCode/Delete/DeleteAttendanceCodeContainer.tsx
+++ b/src/scolar/presentation/ui/AttendanceCode/Delete/DeleteAttendanceCodeContainer.tsx
@@ -1,0 +1,25 @@
+import { toast } from "@/hooks/use-toast";
+import { useInjection } from "inversify-react";
+import { DeleteAttendanceCodePresenter } from "./DeleteAttendanceCodePresenter";
+import { AttendanceCode } from "@/scolar/domain/entities/attendanceCode";
+import { DeleteAttendanceCodeUseCase, DeleteAttendanceCodeCommand } from "@/scolar/application/useCases/attendanceCodes/deleteAttendanceCodeUseCase";
+import { ATTENDANCE_CODE_DELETE_USE_CASE } from "@/scolar/domain/symbols/AttendanceCodeSymbol";
+
+interface Props {
+    attendanceCode: AttendanceCode;
+    onConfirm: () => void;
+}
+
+export const DeleteAttendanceCodeContainer = ({ attendanceCode, onConfirm }: Props) => {
+    const usecase = useInjection<DeleteAttendanceCodeUseCase>(ATTENDANCE_CODE_DELETE_USE_CASE);
+    const handleDelete = async () => {
+        const res = await usecase.execute(new DeleteAttendanceCodeCommand(attendanceCode.id));
+        if (res.isRight()) {
+            toast({ title: 'Código eliminado', description: 'El código de asistencia ha sido eliminado', variant: 'success' });
+            onConfirm();
+        } else {
+            toast({ title: 'Error', description: 'No se pudo eliminar', variant: 'destructive' });
+        }
+    };
+    return <DeleteAttendanceCodePresenter attendanceCode={attendanceCode} onConfirm={handleDelete} />;
+};

--- a/src/scolar/presentation/ui/AttendanceCode/Delete/DeleteAttendanceCodePresenter.tsx
+++ b/src/scolar/presentation/ui/AttendanceCode/Delete/DeleteAttendanceCodePresenter.tsx
@@ -1,0 +1,36 @@
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { AttendanceCode } from "@/scolar/domain/entities/attendanceCode";
+import { Trash2 } from "lucide-react";
+
+interface Props {
+    attendanceCode: AttendanceCode;
+    onConfirm: () => void;
+}
+
+export const DeleteAttendanceCodePresenter = ({ attendanceCode, onConfirm }: Props) => (
+    <Dialog>
+        <DialogTrigger asChild>
+            <Button variant="ghost" size="icon">
+                <Trash2 className="h-4 w-4" />
+                <span className="sr-only">Eliminar</span>
+            </Button>
+        </DialogTrigger>
+        <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+                <DialogTitle>¿Eliminar código de asistencia?</DialogTitle>
+                <DialogDescription>
+                    Esta acción no se puede deshacer.
+                    <br />
+                    <strong>{attendanceCode.code}</strong>
+                </DialogDescription>
+            </DialogHeader>
+            <DialogFooter className="sm:justify-start">
+                <DialogClose asChild>
+                    <Button type="button" variant="destructive" onClick={onConfirm}>Confirmar</Button>
+                </DialogClose>
+                <Button type="button" variant="outline">Cancelar</Button>
+            </DialogFooter>
+        </DialogContent>
+    </Dialog>
+);

--- a/src/scolar/presentation/ui/AttendanceCode/Edit/AttendanceCodeEditContainer.tsx
+++ b/src/scolar/presentation/ui/AttendanceCode/Edit/AttendanceCodeEditContainer.tsx
@@ -1,0 +1,53 @@
+import { startTransition, useCallback, useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { useInjection } from "inversify-react";
+import { toast } from "@/hooks/use-toast";
+import { useNavigate, useParams } from "react-router-dom";
+import { AttendanceCode } from "@/scolar/domain/entities/attendanceCode";
+import { GetAttendanceCodeUseCase, GetAttendanceCodeCommand } from "@/scolar/application/useCases/attendanceCodes/getAttendanceCodeUseCase";
+import { UpdateAttendanceCodeUseCase, UpdateAttendanceCodeCommand } from "@/scolar/application/useCases/attendanceCodes/updateAttendanceCodeUseCase";
+import { ATTENDANCE_CODE_GET_USE_CASE, ATTENDANCE_CODE_UPDATE_USE_CASE } from "@/scolar/domain/symbols/AttendanceCodeSymbol";
+import { AttendanceCodeEditPresenter } from "./AttendanceCodeEditPresenter";
+
+export const AttendanceCodeEditContainer = () => {
+    const { id } = useParams<{ id: string }>();
+    const getUseCase = useInjection<GetAttendanceCodeUseCase>(ATTENDANCE_CODE_GET_USE_CASE);
+    const updateUseCase = useInjection<UpdateAttendanceCodeUseCase>(ATTENDANCE_CODE_UPDATE_USE_CASE);
+    const { register, handleSubmit, formState: { errors }, setValue, watch } = useForm<UpdateAttendanceCodeCommand>({
+        defaultValues: { data: { id: Number(id), code: '', description: '', affectsGrade: false } }
+    });
+    const data = watch();
+
+    const load = useCallback(() => {
+        startTransition(() => {
+            getUseCase.execute(new GetAttendanceCodeCommand(Number(id))).then(res => {
+                if (res.isLeft()) {
+                    toast({ title: 'Error', description: 'No encontrado', variant: 'destructive' });
+                    return;
+                }
+                const m = res.extract() as AttendanceCode;
+                setValue('data.id', m.id);
+                setValue('data.code', m.code);
+                setValue('data.description', m.description);
+                setValue('data.affectsGrade', m.affectsGrade);
+            });
+        });
+    }, [getUseCase, id, setValue]);
+
+    useEffect(() => { load(); }, [load]);
+
+    const onSubmit = () => {
+        startTransition(() => {
+            updateUseCase.execute(new UpdateAttendanceCodeCommand(data.data)).then(res => {
+                if (res.isLeft()) {
+                    toast({ title: 'Error', description: 'No se pudo actualizar', variant: 'destructive' });
+                    return;
+                }
+                toast({ title: 'Actualizado', description: 'Código de asistencia actualizado' });
+            });
+        });
+    };
+    const navigate = useNavigate();
+    const onCancel = () => navigate('/codigos-asistencia');
+    return <AttendanceCodeEditPresenter onSubmit={handleSubmit(onSubmit)} onCancel={onCancel} register={register} errors={errors} isSubmitting={false} />;
+};

--- a/src/scolar/presentation/ui/AttendanceCode/Edit/AttendanceCodeEditPresenter.tsx
+++ b/src/scolar/presentation/ui/AttendanceCode/Edit/AttendanceCodeEditPresenter.tsx
@@ -1,0 +1,45 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Checkbox } from "@/components/ui/checkbox";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+import { UpdateAttendanceCodeCommand } from "@/scolar/application/useCases/attendanceCodes/updateAttendanceCodeUseCase";
+
+interface Props {
+    onSubmit: () => void;
+    onCancel: () => void;
+    register: UseFormRegister<UpdateAttendanceCodeCommand>;
+    errors: FieldErrors<UpdateAttendanceCodeCommand>;
+    isSubmitting: boolean;
+}
+
+export const AttendanceCodeEditPresenter = ({ onSubmit, onCancel, register, errors, isSubmitting }: Props) => (
+    <Card>
+        <form onSubmit={onSubmit}>
+            <CardHeader>
+                <CardTitle>Editar Código de Asistencia</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                <div className="space-y-2">
+                    <Label htmlFor="code">Código</Label>
+                    <Input id="code" {...register("data.code", { required: true })} />
+                    {errors.data?.code && <p className="text-red-500 text-sm">Requerido</p>}
+                </div>
+                <div className="space-y-2">
+                    <Label htmlFor="description">Descripción</Label>
+                    <Textarea id="description" {...register("data.description")}></Textarea>
+                </div>
+                <div className="flex items-center space-x-2">
+                    <Checkbox id="affectsGrade" {...register("data.affectsGrade")} />
+                    <Label htmlFor="affectsGrade">Afecta la calificación</Label>
+                </div>
+            </CardContent>
+            <CardFooter className="flex justify-between">
+                <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>Cancelar</Button>
+                <Button type="submit" disabled={isSubmitting}>{isSubmitting ? 'Guardando...' : 'Guardar'}</Button>
+            </CardFooter>
+        </form>
+    </Card>
+);

--- a/src/scolar/presentation/ui/AttendanceCode/List/AttendanceCodeListContainer.tsx
+++ b/src/scolar/presentation/ui/AttendanceCode/List/AttendanceCodeListContainer.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState, useTransition } from "react";
+import { useInjection } from "inversify-react";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { AttendanceCode } from "@/scolar/domain/entities/attendanceCode";
+import { toast } from "@/hooks/use-toast";
+import { ListAttendanceCodesUseCase, ListAttendanceCodesCommand } from "@/scolar/application/useCases/attendanceCodes/listAttendanceCodesUseCase";
+import { ATTENDANCE_CODE_LIST_USE_CASE } from "@/scolar/domain/symbols/AttendanceCodeSymbol";
+import { AttendanceCodeListPresenter } from "./AttendanceCodeListPresenter";
+import { useNavigate } from "react-router-dom";
+
+export const AttendanceCodeListContainer = () => {
+    const listUseCase = useInjection<ListAttendanceCodesUseCase>(ATTENDANCE_CODE_LIST_USE_CASE);
+    const [isPending, startTransition] = useTransition();
+    const [command, setCommand] = useState({ page: 1, perPage: 10, where: '', orderBy: [] as string[] });
+    const [result, setResult] = useState<PaginatedResult<AttendanceCode>>({
+        data: [],
+        meta: { currentPage: 1, lastPage: 1, next: null, perPage: 10, prev: null, total: 0 }
+    });
+    const debounceRef = useRef<NodeJS.Timeout | null>(null);
+
+    useEffect(() => { handleLoad(); }, [command]);
+
+    const handleLoad = () => {
+        startTransition(() => {
+            listUseCase.execute(new ListAttendanceCodesCommand(command.page, command.perPage, command.orderBy, command.where)).then(res => {
+                if (res.isRight()) {
+                    setResult(res.extract() as PaginatedResult<AttendanceCode>);
+                } else {
+                    toast({ title: 'Error', description: 'Error al cargar', variant: 'destructive' });
+                }
+            });
+        });
+    };
+
+    const navigate = useNavigate();
+    const handleAdd = () => navigate('/codigos-asistencia/nuevo');
+    const handleEdit = (m: AttendanceCode) => navigate(`/codigos-asistencia/${m.id}`);
+    const handlePaginate = (page: number) => setCommand({ ...command, page });
+    const handleSearch = (term: string) => {
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        debounceRef.current = setTimeout(() => setCommand({ ...command, where: term }), 300);
+    };
+
+    return (
+        <AttendanceCodeListPresenter
+            attendanceCodes={result}
+            onAdd={handleAdd}
+            onEdit={handleEdit}
+            onDelete={() => handleLoad()}
+            onPaginate={handlePaginate}
+            isPending={isPending}
+            onSearch={handleSearch}
+        />
+    );
+};

--- a/src/scolar/presentation/ui/AttendanceCode/List/AttendanceCodeListPresenter.tsx
+++ b/src/scolar/presentation/ui/AttendanceCode/List/AttendanceCodeListPresenter.tsx
@@ -1,0 +1,87 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Pagination, PaginationContent, PaginationItem, PaginationLink, PaginationNext, PaginationPrevious } from "@/components/ui/pagination";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Input } from "@/components/ui/input";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { AttendanceCode } from "@/scolar/domain/entities/attendanceCode";
+import { Edit, Plus, Search } from "lucide-react";
+import { DeleteAttendanceCodeContainer } from "../Delete/DeleteAttendanceCodeContainer";
+
+interface Props {
+    attendanceCodes: PaginatedResult<AttendanceCode>;
+    onEdit: (m: AttendanceCode) => void;
+    onDelete: (id: number) => void;
+    onAdd: () => void;
+    onPaginate: (page: number) => void;
+    isPending?: boolean;
+    onSearch: (term: string) => void;
+}
+
+export const AttendanceCodeListPresenter = ({ attendanceCodes, onEdit, onDelete, onAdd, onPaginate, isPending, onSearch }: Props) => (
+    <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+            <CardTitle>Códigos de Asistencia</CardTitle>
+            <Button onClick={onAdd} size="sm"><Plus className="h-4 w-4 mr-2" /> Nuevo</Button>
+        </CardHeader>
+        <CardContent>
+            <div className="relative flex-1 mb-4">
+                <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+                <Input type="search" placeholder="Buscar..." className="pl-9" onChange={(e) => onSearch(e.target.value)} />
+            </div>
+            <Table>
+                <TableHeader>
+                    <TableRow>
+                        <TableHead>Código</TableHead>
+                        <TableHead>Descripción</TableHead>
+                        <TableHead>Afecta nota</TableHead>
+                        <TableHead className="text-right">Acciones</TableHead>
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    {isPending && (
+                        <TableRow>
+                            <TableCell colSpan={4}><Skeleton className="h-4 w-full" /></TableCell>
+                            <TableCell colSpan={4}><Skeleton className="h-4 w-full" /></TableCell>
+                            <TableCell colSpan={4}><Skeleton className="h-4 w-full" /></TableCell>
+                            <TableCell colSpan={4}><Skeleton className="h-4 w-full" /></TableCell>
+                        </TableRow>
+                    )}
+                    {attendanceCodes.data.map((m) => (
+                        <TableRow key={m.id}>
+                            <TableCell className="font-medium">{m.code}</TableCell>
+                            <TableCell>{m.description || '-'}</TableCell>
+                            <TableCell>{m.affectsGrade ? 'Sí' : 'No'}</TableCell>
+                            <TableCell className="text-right">
+                                <div className="flex justify-end gap-2">
+                                    <Button variant="ghost" size="icon" onClick={() => onEdit(m)}>
+                                        <Edit className="h-4 w-4" />
+                                    </Button>
+                                    <DeleteAttendanceCodeContainer attendanceCode={m} onConfirm={() => onDelete(m.id)} />
+                                </div>
+                            </TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+            <div className="mt-4 flex justify-end items-center gap-4">
+                <Pagination>
+                    <PaginationContent>
+                        <PaginationItem>
+                            <PaginationPrevious href="#" className={attendanceCodes.meta.prev ? 'cursor-pointer' : 'cursor-not-allowed'} onClick={() => onPaginate(attendanceCodes.meta.currentPage - 1)} />
+                        </PaginationItem>
+                        {Array.from({ length: attendanceCodes.meta.lastPage }, (_, i) => i + 1).map((page) => (
+                            <PaginationItem key={page}>
+                                <PaginationLink href="#" isActive={page === attendanceCodes.meta.currentPage} onClick={() => onPaginate(page)}>{page}</PaginationLink>
+                            </PaginationItem>
+                        ))}
+                        <PaginationItem>
+                            <PaginationNext href="#" className={attendanceCodes.meta.next ? 'cursor-pointer' : 'cursor-not-allowed'} onClick={() => onPaginate(attendanceCodes.meta.currentPage + 1)} />
+                        </PaginationItem>
+                    </PaginationContent>
+                </Pagination>
+            </div>
+        </CardContent>
+    </Card>
+);

--- a/src/scolar/presentation/ui/BehaviorScale/Create/BehaviorScaleCreateContainer.tsx
+++ b/src/scolar/presentation/ui/BehaviorScale/Create/BehaviorScaleCreateContainer.tsx
@@ -1,0 +1,38 @@
+import { useInjection } from "inversify-react";
+import { BehaviorScaleCreatePresenter } from "./BehaviorScaleCreatePresenter";
+import { CreateBehaviorScaleCommand, CreateBehaviorScaleUseCase } from "@/scolar/application/useCases/behaviorScales/createBehaviorScaleUseCase";
+import { BEHAVIOR_SCALE_CREATE_USE_CASE } from "@/scolar/domain/symbols/BehaviorScaleSymbol";
+import { useForm } from "react-hook-form";
+import { toast } from "@/hooks/use-toast";
+import { useTransition } from "react";
+import { useNavigate } from "react-router-dom";
+
+export const BehaviorScaleCreateContainer = () => {
+    const usecase = useInjection<CreateBehaviorScaleUseCase>(BEHAVIOR_SCALE_CREATE_USE_CASE);
+    const [isPending, startTransition] = useTransition();
+    const { register, handleSubmit, formState: { errors } } = useForm<CreateBehaviorScaleCommand>({
+        defaultValues: { data: { id: 0, name: '', minScore: '', maxScore: '' } }
+    });
+    const onSubmit = (data: CreateBehaviorScaleCommand) => {
+        startTransition(async () => {
+            const res = await usecase.execute(new CreateBehaviorScaleCommand(data.data));
+            if (res.isLeft()) {
+                toast({ title: 'Error', description: 'No se pudo crear', variant: 'destructive' });
+                return;
+            }
+            toast({ title: 'Escala creada', description: `Escala ${data.data.name} creada`, variant: 'success' });
+            navigate('/escalas-comportamiento');
+        });
+    };
+    const navigate = useNavigate();
+    const onCancel = () => navigate('/escalas-comportamiento');
+    return (
+        <BehaviorScaleCreatePresenter
+            onSubmit={handleSubmit(onSubmit)}
+            onCancel={onCancel}
+            register={register}
+            errors={errors}
+            isSubmitting={isPending}
+        />
+    );
+};

--- a/src/scolar/presentation/ui/BehaviorScale/Create/BehaviorScaleCreatePresenter.tsx
+++ b/src/scolar/presentation/ui/BehaviorScale/Create/BehaviorScaleCreatePresenter.tsx
@@ -1,0 +1,43 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+import { CreateBehaviorScaleCommand } from "@/scolar/application/useCases/behaviorScales/createBehaviorScaleUseCase";
+
+interface Props {
+    onSubmit: () => void;
+    onCancel: () => void;
+    register: UseFormRegister<CreateBehaviorScaleCommand>;
+    errors: FieldErrors<CreateBehaviorScaleCommand>;
+    isSubmitting: boolean;
+}
+
+export const BehaviorScaleCreatePresenter = ({ onSubmit, onCancel, register, errors, isSubmitting }: Props) => (
+    <Card>
+        <form onSubmit={onSubmit}>
+            <CardHeader>
+                <CardTitle>Crear Escala de Comportamiento</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                <div className="space-y-2">
+                    <Label htmlFor="name">Nombre</Label>
+                    <Input id="name" {...register("data.name", { required: true })} />
+                    {errors.data?.name && <p className="text-red-500 text-sm">Requerido</p>}
+                </div>
+                <div className="space-y-2">
+                    <Label htmlFor="minScore">Puntaje mínimo</Label>
+                    <Input id="minScore" {...register("data.minScore", { required: true })} />
+                </div>
+                <div className="space-y-2">
+                    <Label htmlFor="maxScore">Puntaje máximo</Label>
+                    <Input id="maxScore" {...register("data.maxScore", { required: true })} />
+                </div>
+            </CardContent>
+            <CardFooter className="flex justify-between">
+                <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>Cancelar</Button>
+                <Button type="submit" disabled={isSubmitting}>{isSubmitting ? 'Guardando...' : 'Guardar'}</Button>
+            </CardFooter>
+        </form>
+    </Card>
+);

--- a/src/scolar/presentation/ui/BehaviorScale/Delete/DeleteBehaviorScaleContainer.tsx
+++ b/src/scolar/presentation/ui/BehaviorScale/Delete/DeleteBehaviorScaleContainer.tsx
@@ -1,0 +1,25 @@
+import { toast } from "@/hooks/use-toast";
+import { useInjection } from "inversify-react";
+import { DeleteBehaviorScalePresenter } from "./DeleteBehaviorScalePresenter";
+import { BehaviorScale } from "@/scolar/domain/entities/behaviorScale";
+import { DeleteBehaviorScaleUseCase, DeleteBehaviorScaleCommand } from "@/scolar/application/useCases/behaviorScales/deleteBehaviorScaleUseCase";
+import { BEHAVIOR_SCALE_DELETE_USE_CASE } from "@/scolar/domain/symbols/BehaviorScaleSymbol";
+
+interface Props {
+    behaviorScale: BehaviorScale;
+    onConfirm: () => void;
+}
+
+export const DeleteBehaviorScaleContainer = ({ behaviorScale, onConfirm }: Props) => {
+    const usecase = useInjection<DeleteBehaviorScaleUseCase>(BEHAVIOR_SCALE_DELETE_USE_CASE);
+    const handleDelete = async () => {
+        const res = await usecase.execute(new DeleteBehaviorScaleCommand(behaviorScale.id));
+        if (res.isRight()) {
+            toast({ title: 'Escala eliminada', description: 'La escala ha sido eliminada', variant: 'success' });
+            onConfirm();
+        } else {
+            toast({ title: 'Error', description: 'No se pudo eliminar', variant: 'destructive' });
+        }
+    };
+    return <DeleteBehaviorScalePresenter behaviorScale={behaviorScale} onConfirm={handleDelete} />;
+};

--- a/src/scolar/presentation/ui/BehaviorScale/Delete/DeleteBehaviorScalePresenter.tsx
+++ b/src/scolar/presentation/ui/BehaviorScale/Delete/DeleteBehaviorScalePresenter.tsx
@@ -1,0 +1,36 @@
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { BehaviorScale } from "@/scolar/domain/entities/behaviorScale";
+import { Trash2 } from "lucide-react";
+
+interface Props {
+    behaviorScale: BehaviorScale;
+    onConfirm: () => void;
+}
+
+export const DeleteBehaviorScalePresenter = ({ behaviorScale, onConfirm }: Props) => (
+    <Dialog>
+        <DialogTrigger asChild>
+            <Button variant="ghost" size="icon">
+                <Trash2 className="h-4 w-4" />
+                <span className="sr-only">Eliminar</span>
+            </Button>
+        </DialogTrigger>
+        <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+                <DialogTitle>¿Eliminar escala de comportamiento?</DialogTitle>
+                <DialogDescription>
+                    Esta acción no se puede deshacer.
+                    <br />
+                    <strong>{behaviorScale.name}</strong>
+                </DialogDescription>
+            </DialogHeader>
+            <DialogFooter className="sm:justify-start">
+                <DialogClose asChild>
+                    <Button type="button" variant="destructive" onClick={onConfirm}>Confirmar</Button>
+                </DialogClose>
+                <Button type="button" variant="outline">Cancelar</Button>
+            </DialogFooter>
+        </DialogContent>
+    </Dialog>
+);

--- a/src/scolar/presentation/ui/BehaviorScale/Edit/BehaviorScaleEditContainer.tsx
+++ b/src/scolar/presentation/ui/BehaviorScale/Edit/BehaviorScaleEditContainer.tsx
@@ -1,0 +1,53 @@
+import { startTransition, useCallback, useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { useInjection } from "inversify-react";
+import { toast } from "@/hooks/use-toast";
+import { useNavigate, useParams } from "react-router-dom";
+import { BehaviorScale } from "@/scolar/domain/entities/behaviorScale";
+import { GetBehaviorScaleUseCase, GetBehaviorScaleCommand } from "@/scolar/application/useCases/behaviorScales/getBehaviorScaleUseCase";
+import { UpdateBehaviorScaleUseCase, UpdateBehaviorScaleCommand } from "@/scolar/application/useCases/behaviorScales/updateBehaviorScaleUseCase";
+import { BEHAVIOR_SCALE_GET_USE_CASE, BEHAVIOR_SCALE_UPDATE_USE_CASE } from "@/scolar/domain/symbols/BehaviorScaleSymbol";
+import { BehaviorScaleEditPresenter } from "./BehaviorScaleEditPresenter";
+
+export const BehaviorScaleEditContainer = () => {
+    const { id } = useParams<{ id: string }>();
+    const getUseCase = useInjection<GetBehaviorScaleUseCase>(BEHAVIOR_SCALE_GET_USE_CASE);
+    const updateUseCase = useInjection<UpdateBehaviorScaleUseCase>(BEHAVIOR_SCALE_UPDATE_USE_CASE);
+    const { register, handleSubmit, formState: { errors }, setValue, watch } = useForm<UpdateBehaviorScaleCommand>({
+        defaultValues: { data: { id: Number(id), name: '', minScore: '', maxScore: '' } }
+    });
+    const data = watch();
+
+    const load = useCallback(() => {
+        startTransition(() => {
+            getUseCase.execute(new GetBehaviorScaleCommand(Number(id))).then(res => {
+                if (res.isLeft()) {
+                    toast({ title: 'Error', description: 'No encontrado', variant: 'destructive' });
+                    return;
+                }
+                const m = res.extract() as BehaviorScale;
+                setValue('data.id', m.id);
+                setValue('data.name', m.name);
+                setValue('data.minScore', m.minScore);
+                setValue('data.maxScore', m.maxScore);
+            });
+        });
+    }, [getUseCase, id, setValue]);
+
+    useEffect(() => { load(); }, [load]);
+
+    const onSubmit = () => {
+        startTransition(() => {
+            updateUseCase.execute(new UpdateBehaviorScaleCommand(data.data)).then(res => {
+                if (res.isLeft()) {
+                    toast({ title: 'Error', description: 'No se pudo actualizar', variant: 'destructive' });
+                    return;
+                }
+                toast({ title: 'Actualizado', description: 'Escala de comportamiento actualizada' });
+            });
+        });
+    };
+    const navigate = useNavigate();
+    const onCancel = () => navigate('/escalas-comportamiento');
+    return <BehaviorScaleEditPresenter onSubmit={handleSubmit(onSubmit)} onCancel={onCancel} register={register} errors={errors} isSubmitting={false} />;
+};

--- a/src/scolar/presentation/ui/BehaviorScale/Edit/BehaviorScaleEditPresenter.tsx
+++ b/src/scolar/presentation/ui/BehaviorScale/Edit/BehaviorScaleEditPresenter.tsx
@@ -1,0 +1,43 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+import { UpdateBehaviorScaleCommand } from "@/scolar/application/useCases/behaviorScales/updateBehaviorScaleUseCase";
+
+interface Props {
+    onSubmit: () => void;
+    onCancel: () => void;
+    register: UseFormRegister<UpdateBehaviorScaleCommand>;
+    errors: FieldErrors<UpdateBehaviorScaleCommand>;
+    isSubmitting: boolean;
+}
+
+export const BehaviorScaleEditPresenter = ({ onSubmit, onCancel, register, errors, isSubmitting }: Props) => (
+    <Card>
+        <form onSubmit={onSubmit}>
+            <CardHeader>
+                <CardTitle>Editar Escala de Comportamiento</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                <div className="space-y-2">
+                    <Label htmlFor="name">Nombre</Label>
+                    <Input id="name" {...register("data.name", { required: true })} />
+                    {errors.data?.name && <p className="text-red-500 text-sm">Requerido</p>}
+                </div>
+                <div className="space-y-2">
+                    <Label htmlFor="minScore">Puntaje mínimo</Label>
+                    <Input id="minScore" {...register("data.minScore", { required: true })} />
+                </div>
+                <div className="space-y-2">
+                    <Label htmlFor="maxScore">Puntaje máximo</Label>
+                    <Input id="maxScore" {...register("data.maxScore", { required: true })} />
+                </div>
+            </CardContent>
+            <CardFooter className="flex justify-between">
+                <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>Cancelar</Button>
+                <Button type="submit" disabled={isSubmitting}>{isSubmitting ? 'Guardando...' : 'Guardar'}</Button>
+            </CardFooter>
+        </form>
+    </Card>
+);

--- a/src/scolar/presentation/ui/BehaviorScale/List/BehaviorScaleListContainer.tsx
+++ b/src/scolar/presentation/ui/BehaviorScale/List/BehaviorScaleListContainer.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState, useTransition } from "react";
+import { useInjection } from "inversify-react";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { BehaviorScale } from "@/scolar/domain/entities/behaviorScale";
+import { toast } from "@/hooks/use-toast";
+import { ListBehaviorScalesUseCase, ListBehaviorScalesCommand } from "@/scolar/application/useCases/behaviorScales/listBehaviorScalesUseCase";
+import { BEHAVIOR_SCALE_LIST_USE_CASE } from "@/scolar/domain/symbols/BehaviorScaleSymbol";
+import { BehaviorScaleListPresenter } from "./BehaviorScaleListPresenter";
+import { useNavigate } from "react-router-dom";
+
+export const BehaviorScaleListContainer = () => {
+    const listUseCase = useInjection<ListBehaviorScalesUseCase>(BEHAVIOR_SCALE_LIST_USE_CASE);
+    const [isPending, startTransition] = useTransition();
+    const [command, setCommand] = useState({ page: 1, perPage: 10, where: '', orderBy: [] as string[] });
+    const [result, setResult] = useState<PaginatedResult<BehaviorScale>>({
+        data: [],
+        meta: { currentPage: 1, lastPage: 1, next: null, perPage: 10, prev: null, total: 0 }
+    });
+    const debounceRef = useRef<NodeJS.Timeout | null>(null);
+
+    useEffect(() => { handleLoad(); }, [command]);
+
+    const handleLoad = () => {
+        startTransition(() => {
+            listUseCase.execute(new ListBehaviorScalesCommand(command.page, command.perPage, command.orderBy, command.where)).then(res => {
+                if (res.isRight()) {
+                    setResult(res.extract() as PaginatedResult<BehaviorScale>);
+                } else {
+                    toast({ title: 'Error', description: 'Error al cargar', variant: 'destructive' });
+                }
+            });
+        });
+    };
+
+    const navigate = useNavigate();
+    const handleAdd = () => navigate('/escalas-comportamiento/nuevo');
+    const handleEdit = (m: BehaviorScale) => navigate(`/escalas-comportamiento/${m.id}`);
+    const handlePaginate = (page: number) => setCommand({ ...command, page });
+    const handleSearch = (term: string) => {
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        debounceRef.current = setTimeout(() => setCommand({ ...command, where: term }), 300);
+    };
+
+    return (
+        <BehaviorScaleListPresenter
+            behaviorScales={result}
+            onAdd={handleAdd}
+            onEdit={handleEdit}
+            onDelete={() => handleLoad()}
+            onPaginate={handlePaginate}
+            isPending={isPending}
+            onSearch={handleSearch}
+        />
+    );
+};

--- a/src/scolar/presentation/ui/BehaviorScale/List/BehaviorScaleListPresenter.tsx
+++ b/src/scolar/presentation/ui/BehaviorScale/List/BehaviorScaleListPresenter.tsx
@@ -1,0 +1,87 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Pagination, PaginationContent, PaginationItem, PaginationLink, PaginationNext, PaginationPrevious } from "@/components/ui/pagination";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Input } from "@/components/ui/input";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { BehaviorScale } from "@/scolar/domain/entities/behaviorScale";
+import { Edit, Plus, Search } from "lucide-react";
+import { DeleteBehaviorScaleContainer } from "../Delete/DeleteBehaviorScaleContainer";
+
+interface Props {
+    behaviorScales: PaginatedResult<BehaviorScale>;
+    onEdit: (m: BehaviorScale) => void;
+    onDelete: (id: number) => void;
+    onAdd: () => void;
+    onPaginate: (page: number) => void;
+    isPending?: boolean;
+    onSearch: (term: string) => void;
+}
+
+export const BehaviorScaleListPresenter = ({ behaviorScales, onEdit, onDelete, onAdd, onPaginate, isPending, onSearch }: Props) => (
+    <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+            <CardTitle>Escalas de Comportamiento</CardTitle>
+            <Button onClick={onAdd} size="sm"><Plus className="h-4 w-4 mr-2" /> Nuevo</Button>
+        </CardHeader>
+        <CardContent>
+            <div className="relative flex-1 mb-4">
+                <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+                <Input type="search" placeholder="Buscar..." className="pl-9" onChange={(e) => onSearch(e.target.value)} />
+            </div>
+            <Table>
+                <TableHeader>
+                    <TableRow>
+                        <TableHead>Nombre</TableHead>
+                        <TableHead>Puntaje Min</TableHead>
+                        <TableHead>Puntaje Max</TableHead>
+                        <TableHead className="text-right">Acciones</TableHead>
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    {isPending && (
+                        <TableRow>
+                            <TableCell colSpan={4}><Skeleton className="h-4 w-full" /></TableCell>
+                            <TableCell colSpan={4}><Skeleton className="h-4 w-full" /></TableCell>
+                            <TableCell colSpan={4}><Skeleton className="h-4 w-full" /></TableCell>
+                            <TableCell colSpan={4}><Skeleton className="h-4 w-full" /></TableCell>
+                        </TableRow>
+                    )}
+                    {behaviorScales.data.map((m) => (
+                        <TableRow key={m.id}>
+                            <TableCell className="font-medium">{m.name}</TableCell>
+                            <TableCell>{m.minScore}</TableCell>
+                            <TableCell>{m.maxScore}</TableCell>
+                            <TableCell className="text-right">
+                                <div className="flex justify-end gap-2">
+                                    <Button variant="ghost" size="icon" onClick={() => onEdit(m)}>
+                                        <Edit className="h-4 w-4" />
+                                    </Button>
+                                    <DeleteBehaviorScaleContainer behaviorScale={m} onConfirm={() => onDelete(m.id)} />
+                                </div>
+                            </TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+            <div className="mt-4 flex justify-end items-center gap-4">
+                <Pagination>
+                    <PaginationContent>
+                        <PaginationItem>
+                            <PaginationPrevious href="#" className={behaviorScales.meta.prev ? 'cursor-pointer' : 'cursor-not-allowed'} onClick={() => onPaginate(behaviorScales.meta.currentPage - 1)} />
+                        </PaginationItem>
+                        {Array.from({ length: behaviorScales.meta.lastPage }, (_, i) => i + 1).map((page) => (
+                            <PaginationItem key={page}>
+                                <PaginationLink href="#" isActive={page === behaviorScales.meta.currentPage} onClick={() => onPaginate(page)}>{page}</PaginationLink>
+                            </PaginationItem>
+                        ))}
+                        <PaginationItem>
+                            <PaginationNext href="#" className={behaviorScales.meta.next ? 'cursor-pointer' : 'cursor-not-allowed'} onClick={() => onPaginate(behaviorScales.meta.currentPage + 1)} />
+                        </PaginationItem>
+                    </PaginationContent>
+                </Pagination>
+            </div>
+        </CardContent>
+    </Card>
+);

--- a/src/scolar/presentation/ui/ClassSchedule/Calendar/ClassScheduleCalendarContainer.tsx
+++ b/src/scolar/presentation/ui/ClassSchedule/Calendar/ClassScheduleCalendarContainer.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useState, useTransition } from "react";
+import { useInjection } from "inversify-react";
+import { useForm } from "react-hook-form";
+import { toast } from "@/hooks/use-toast";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ClassSchedule } from "@/scolar/domain/entities/classSchedule";
+import { ListClassSchedulesUseCase, ListClassSchedulesCommand } from "@/scolar/application/useCases/classSchedules/listClassSchedulesUseCase";
+import { CreateClassScheduleUseCase, CreateClassScheduleCommand } from "@/scolar/application/useCases/classSchedules/createClassScheduleUseCase";
+import { UpdateClassScheduleUseCase, UpdateClassScheduleCommand } from "@/scolar/application/useCases/classSchedules/updateClassScheduleUseCase";
+import { DeleteClassScheduleUseCase, DeleteClassScheduleCommand } from "@/scolar/application/useCases/classSchedules/deleteClassScheduleUseCase";
+import { CLASS_SCHEDULE_LIST_USE_CASE, CLASS_SCHEDULE_CREATE_USE_CASE, CLASS_SCHEDULE_UPDATE_USE_CASE, CLASS_SCHEDULE_DELETE_USE_CASE } from "@/scolar/domain/symbols/ClassScheduleSymbol";
+import { ClassScheduleCalendarPresenter } from "./ClassScheduleCalendarPresenter";
+
+export const ClassScheduleCalendarContainer = () => {
+    const listUseCase = useInjection<ListClassSchedulesUseCase>(CLASS_SCHEDULE_LIST_USE_CASE);
+    const createUseCase = useInjection<CreateClassScheduleUseCase>(CLASS_SCHEDULE_CREATE_USE_CASE);
+    const updateUseCase = useInjection<UpdateClassScheduleUseCase>(CLASS_SCHEDULE_UPDATE_USE_CASE);
+    const deleteUseCase = useInjection<DeleteClassScheduleUseCase>(CLASS_SCHEDULE_DELETE_USE_CASE);
+
+    const [schedules, setSchedules] = useState<ClassSchedule[]>([]);
+    const [open, setOpen] = useState(false);
+    const [editing, setEditing] = useState<ClassSchedule | null>(null);
+    const [isPending, startTransition] = useTransition();
+
+    const { register, handleSubmit, reset } = useForm<ClassSchedule>({
+        defaultValues: { id: 0, courseId: 0, parallelId: 0, schoolYearId: 0, subjectId: 0, dayOfWeek: "", startTime: "", endTime: "" }
+    });
+
+    const load = () => {
+        startTransition(() => {
+            listUseCase.execute(new ListClassSchedulesCommand(1, 100, [], "")).then(res => {
+                if (res.isRight()) {
+                    setSchedules(res.extract()!.data);
+                } else {
+                    toast({ title: "Error", description: "No se pudo cargar", variant: "destructive" });
+                }
+            });
+        });
+    };
+
+    useEffect(() => {
+        load();
+    }, []);
+
+    const handleAdd = (day?: string) => {
+        setEditing(null);
+        reset({ id: 0, courseId: 0, parallelId: 0, schoolYearId: 0, subjectId: 0, dayOfWeek: day || "", startTime: "", endTime: "" });
+        setOpen(true);
+    };
+
+    const handleSelect = (s: ClassSchedule) => {
+        setEditing(s);
+        reset(s);
+        setOpen(true);
+    };
+
+    const onSubmit = handleSubmit((data) => {
+        startTransition(async () => {
+            if (editing) {
+                const res = await updateUseCase.execute(new UpdateClassScheduleCommand(data));
+                if (res.isLeft()) {
+                    toast({ title: "Error", description: "No se pudo actualizar", variant: "destructive" });
+                    return;
+                }
+                toast({ title: "Horario actualizado", description: "Actualizado correctamente", variant: "success" });
+            } else {
+                const res = await createUseCase.execute(new CreateClassScheduleCommand(data));
+                if (res.isLeft()) {
+                    toast({ title: "Error", description: "No se pudo crear", variant: "destructive" });
+                    return;
+                }
+                toast({ title: "Horario creado", description: "Creado correctamente", variant: "success" });
+            }
+            setOpen(false);
+            load();
+        });
+    });
+
+    const handleDelete = () => {
+        if (!editing) return;
+        startTransition(async () => {
+            const res = await deleteUseCase.execute(new DeleteClassScheduleCommand(editing.id));
+            if (res.isLeft()) {
+                toast({ title: "Error", description: "No se pudo eliminar", variant: "destructive" });
+                return;
+            }
+            toast({ title: "Horario eliminado", description: "Eliminado correctamente", variant: "success" });
+            setOpen(false);
+            load();
+        });
+    };
+
+    return (
+        <>
+            <ClassScheduleCalendarPresenter schedules={schedules} onAdd={handleAdd} onSelect={handleSelect} />
+            <Dialog open={open} onOpenChange={setOpen}>
+                <DialogContent>
+                    <form onSubmit={onSubmit} className="space-y-4">
+                        <DialogHeader>
+                            <DialogTitle>{editing ? "Editar Horario" : "Agregar Horario"}</DialogTitle>
+                        </DialogHeader>
+                        <div className="grid grid-cols-2 gap-4">
+                            <div className="space-y-2">
+                                <Label htmlFor="courseId">Curso ID</Label>
+                                <Input id="courseId" type="number" {...register("courseId", { valueAsNumber: true, required: true })} />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="parallelId">Paralelo ID</Label>
+                                <Input id="parallelId" type="number" {...register("parallelId", { valueAsNumber: true, required: true })} />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="schoolYearId">Periodo Lectivo ID</Label>
+                                <Input id="schoolYearId" type="number" {...register("schoolYearId", { valueAsNumber: true, required: true })} />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="subjectId">Materia ID</Label>
+                                <Input id="subjectId" type="number" {...register("subjectId", { valueAsNumber: true, required: true })} />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="dayOfWeek">Día</Label>
+                                <Input id="dayOfWeek" {...register("dayOfWeek", { required: true })} />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="startTime">Inicio</Label>
+                                <Input id="startTime" {...register("startTime", { required: true })} />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="endTime">Fin</Label>
+                                <Input id="endTime" {...register("endTime", { required: true })} />
+                            </div>
+                        </div>
+                        <DialogFooter className="flex justify-between">
+                            {editing && <Button type="button" variant="destructive" onClick={handleDelete} disabled={isPending}>Eliminar</Button>}
+                            <div className="ml-auto flex gap-2">
+                                <Button type="button" variant="outline" onClick={() => setOpen(false)} disabled={isPending}>Cancelar</Button>
+                                <Button type="submit" disabled={isPending}>{isPending ? "Guardando..." : "Guardar"}</Button>
+                            </div>
+                        </DialogFooter>
+                    </form>
+                </DialogContent>
+            </Dialog>
+        </>
+    );
+};
+

--- a/src/scolar/presentation/ui/ClassSchedule/Calendar/ClassScheduleCalendarPresenter.tsx
+++ b/src/scolar/presentation/ui/ClassSchedule/Calendar/ClassScheduleCalendarPresenter.tsx
@@ -1,0 +1,57 @@
+import { Button } from "@/components/ui/button";
+import { ClassSchedule } from "@/scolar/domain/entities/classSchedule";
+
+interface Props {
+    schedules: ClassSchedule[];
+    onAdd: (day?: string) => void;
+    onSelect: (s: ClassSchedule) => void;
+}
+
+export const ClassScheduleCalendarPresenter = ({ schedules, onAdd, onSelect }: Props) => {
+    const days = ["Lunes", "Martes", "Miércoles", "Jueves", "Viernes", "Sábado"];
+    const startHour = 7;
+    const endHour = 20;
+    const totalMinutes = (endHour - startHour) * 60;
+    const containerHeight = 600; // px
+
+    const timeToMinutes = (time: string) => {
+        const [h, m] = time.split(":").map(Number);
+        return h * 60 + m;
+    };
+
+    return (
+        <div className="space-y-4">
+            <div className="flex justify-between items-center">
+                <h1 className="text-xl font-bold">Horarios de Clase</h1>
+                <Button onClick={() => onAdd()}>Agregar Clase</Button>
+            </div>
+            <div className="grid grid-cols-6 gap-2">
+                {days.map(day => (
+                    <div
+                        key={day}
+                        className="border rounded-md h-[600px] relative"
+                        onClick={() => onAdd(day)}
+                    >
+                        <div className="text-center font-medium border-b">{day}</div>
+                        {schedules.filter(s => s.dayOfWeek === day).map(s => {
+                            const top = ((timeToMinutes(s.startTime) - startHour * 60) / totalMinutes) * containerHeight;
+                            const height = ((timeToMinutes(s.endTime) - timeToMinutes(s.startTime)) / totalMinutes) * containerHeight;
+                            return (
+                                <div
+                                    key={s.id}
+                                    data-type="block"
+                                    onClick={(e) => { e.stopPropagation(); onSelect(s); }}
+                                    className="absolute left-1 right-1 bg-blue-500 text-white rounded p-1 text-xs overflow-hidden cursor-pointer"
+                                    style={{ top: `${top}px`, height: `${height}px` }}
+                                >
+                                    <div>{s.startTime} - {s.endTime}</div>
+                                </div>
+                            );
+                        })}
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};
+

--- a/src/scolar/presentation/ui/ClassSchedule/Create/ClassScheduleCreateContainer.tsx
+++ b/src/scolar/presentation/ui/ClassSchedule/Create/ClassScheduleCreateContainer.tsx
@@ -1,0 +1,38 @@
+import { useInjection } from "inversify-react";
+import { ClassScheduleCreatePresenter } from "./ClassScheduleCreatePresenter";
+import { CreateClassScheduleCommand, CreateClassScheduleUseCase } from "@/scolar/application/useCases/classSchedules/createClassScheduleUseCase";
+import { CLASS_SCHEDULE_CREATE_USE_CASE } from "@/scolar/domain/symbols/ClassScheduleSymbol";
+import { useForm } from "react-hook-form";
+import { toast } from "@/hooks/use-toast";
+import { useTransition } from "react";
+import { useNavigate } from "react-router-dom";
+
+export const ClassScheduleCreateContainer = () => {
+    const usecase = useInjection<CreateClassScheduleUseCase>(CLASS_SCHEDULE_CREATE_USE_CASE);
+    const [isPending, startTransition] = useTransition();
+    const { register, handleSubmit, formState: { errors } } = useForm<CreateClassScheduleCommand>({
+        defaultValues: { data: { id: 0, courseId: 0, parallelId: 0, schoolYearId: 0, subjectId: 0, dayOfWeek: '', startTime: '', endTime: '' } }
+    });
+    const navigate = useNavigate();
+    const onSubmit = (data: CreateClassScheduleCommand) => {
+        startTransition(async () => {
+            const res = await usecase.execute(new CreateClassScheduleCommand(data.data));
+            if (res.isLeft()) {
+                toast({ title: 'Error', description: 'No se pudo crear', variant: 'destructive' });
+                return;
+            }
+            toast({ title: 'Horario creado', description: 'Horario creado correctamente', variant: 'success' });
+            navigate('/horarios-clase');
+        });
+    };
+    const onCancel = () => navigate('/horarios-clase');
+    return (
+        <ClassScheduleCreatePresenter
+            onSubmit={handleSubmit(onSubmit)}
+            onCancel={onCancel}
+            register={register}
+            errors={errors}
+            isSubmitting={isPending}
+        />
+    );
+};

--- a/src/scolar/presentation/ui/ClassSchedule/Create/ClassScheduleCreatePresenter.tsx
+++ b/src/scolar/presentation/ui/ClassSchedule/Create/ClassScheduleCreatePresenter.tsx
@@ -1,0 +1,69 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+import { CreateClassScheduleCommand } from "@/scolar/application/useCases/classSchedules/createClassScheduleUseCase";
+
+interface Props {
+    onSubmit: () => void;
+    onCancel: () => void;
+    register: UseFormRegister<CreateClassScheduleCommand>;
+    errors: FieldErrors<CreateClassScheduleCommand>;
+    isSubmitting: boolean;
+}
+
+export const ClassScheduleCreatePresenter = ({ onSubmit, onCancel, register, errors, isSubmitting }: Props) => {
+    return (
+        <Card>
+            <form onSubmit={onSubmit}>
+                <CardHeader>
+                    <CardTitle>Crear Horario</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                    <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                            <Label htmlFor="courseId">Curso ID</Label>
+                            <Input id="courseId" type="number" {...register("data.courseId", { valueAsNumber: true, required: true })} />
+                            {errors.data?.courseId && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="parallelId">Paralelo ID</Label>
+                            <Input id="parallelId" type="number" {...register("data.parallelId", { valueAsNumber: true, required: true })} />
+                            {errors.data?.parallelId && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="schoolYearId">Periodo Lectivo ID</Label>
+                            <Input id="schoolYearId" type="number" {...register("data.schoolYearId", { valueAsNumber: true, required: true })} />
+                            {errors.data?.schoolYearId && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="subjectId">Materia ID</Label>
+                            <Input id="subjectId" type="number" {...register("data.subjectId", { valueAsNumber: true, required: true })} />
+                            {errors.data?.subjectId && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="dayOfWeek">Día de la semana</Label>
+                            <Input id="dayOfWeek" {...register("data.dayOfWeek", { required: true })} />
+                            {errors.data?.dayOfWeek && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="startTime">Hora inicio</Label>
+                            <Input id="startTime" {...register("data.startTime", { required: true })} />
+                            {errors.data?.startTime && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="endTime">Hora fin</Label>
+                            <Input id="endTime" {...register("data.endTime", { required: true })} />
+                            {errors.data?.endTime && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                    </div>
+                </CardContent>
+                <CardFooter className="flex justify-between">
+                    <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>Cancelar</Button>
+                    <Button type="submit" disabled={isSubmitting}>{isSubmitting ? 'Guardando...' : 'Guardar'}</Button>
+                </CardFooter>
+            </form>
+        </Card>
+    );
+};

--- a/src/scolar/presentation/ui/ClassSchedule/Delete/DeleteClassScheduleContainer.tsx
+++ b/src/scolar/presentation/ui/ClassSchedule/Delete/DeleteClassScheduleContainer.tsx
@@ -1,0 +1,33 @@
+import { toast } from "@/hooks/use-toast";
+import { useInjection } from "inversify-react";
+import { DeleteClassSchedulePresenter } from "./DeleteClassSchedulePresenter";
+import { ClassSchedule } from "@/scolar/domain/entities/classSchedule";
+import { DeleteClassScheduleCommand, DeleteClassScheduleUseCase } from "@/scolar/application/useCases/classSchedules/deleteClassScheduleUseCase";
+import { CLASS_SCHEDULE_DELETE_USE_CASE } from "@/scolar/domain/symbols/ClassScheduleSymbol";
+
+interface Props {
+    schedule: ClassSchedule;
+    onConfirm: () => void;
+}
+
+export const DeleteClassScheduleContainer = ({ schedule, onConfirm }: Props) => {
+    const usecase = useInjection<DeleteClassScheduleUseCase>(CLASS_SCHEDULE_DELETE_USE_CASE);
+    const handleDelete = async () => {
+        const res = await usecase.execute(new DeleteClassScheduleCommand(schedule.id));
+        if (res.isRight()) {
+            toast({
+                title: "Horario eliminado",
+                description: "El horario ha sido eliminado correctamente",
+                variant: "success",
+            });
+            onConfirm();
+        } else {
+            toast({
+                title: "Error eliminando",
+                description: "No se pudo eliminar el horario",
+                variant: "destructive",
+            });
+        }
+    };
+    return <DeleteClassSchedulePresenter schedule={schedule} onConfirm={handleDelete} />;
+};

--- a/src/scolar/presentation/ui/ClassSchedule/Delete/DeleteClassSchedulePresenter.tsx
+++ b/src/scolar/presentation/ui/ClassSchedule/Delete/DeleteClassSchedulePresenter.tsx
@@ -1,0 +1,42 @@
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { ClassSchedule } from "@/scolar/domain/entities/classSchedule";
+import { Trash2 } from "lucide-react";
+
+interface Props {
+    schedule: ClassSchedule;
+    onConfirm: () => void;
+}
+
+export const DeleteClassSchedulePresenter = ({ schedule, onConfirm }: Props) => {
+    return (
+        <Dialog>
+            <DialogTrigger asChild>
+                <Button variant="ghost" size="icon">
+                    <Trash2 className="h-4 w-4" />
+                    <span className="sr-only">Eliminar</span>
+                </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle>¿Eliminar horario?</DialogTitle>
+                    <DialogDescription>
+                        Esta acción no se puede deshacer.
+                        <br />
+                        <strong>{schedule.dayOfWeek} {schedule.startTime}-{schedule.endTime}</strong>
+                    </DialogDescription>
+                </DialogHeader>
+                <DialogFooter className="sm:justify-start">
+                    <DialogClose asChild>
+                        <Button type="button" variant="destructive" onClick={onConfirm}>
+                            Confirmar
+                        </Button>
+                    </DialogClose>
+                    <Button type="button" variant="outline">
+                        Cancelar
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};

--- a/src/scolar/presentation/ui/ClassSchedule/Edit/ClassScheduleEditContainer.tsx
+++ b/src/scolar/presentation/ui/ClassSchedule/Edit/ClassScheduleEditContainer.tsx
@@ -1,0 +1,57 @@
+import { startTransition, useCallback, useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { useInjection } from "inversify-react";
+import { toast } from "@/hooks/use-toast";
+import { useNavigate, useParams } from "react-router-dom";
+import { ClassSchedule } from "@/scolar/domain/entities/classSchedule";
+import { GetClassScheduleUseCase, GetClassScheduleCommand } from "@/scolar/application/useCases/classSchedules/getClassScheduleUseCase";
+import { UpdateClassScheduleUseCase, UpdateClassScheduleCommand } from "@/scolar/application/useCases/classSchedules/updateClassScheduleUseCase";
+import { CLASS_SCHEDULE_GET_USE_CASE, CLASS_SCHEDULE_UPDATE_USE_CASE } from "@/scolar/domain/symbols/ClassScheduleSymbol";
+import { ClassScheduleEditPresenter } from "./ClassScheduleEditPresenter";
+
+export const ClassScheduleEditContainer = () => {
+    const { id } = useParams<{ id: string }>();
+    const getUseCase = useInjection<GetClassScheduleUseCase>(CLASS_SCHEDULE_GET_USE_CASE);
+    const updateUseCase = useInjection<UpdateClassScheduleUseCase>(CLASS_SCHEDULE_UPDATE_USE_CASE);
+    const { register, handleSubmit, formState: { errors }, setValue, watch } = useForm<UpdateClassScheduleCommand>({
+        defaultValues: { data: { id: Number(id), courseId: 0, parallelId: 0, schoolYearId: 0, subjectId: 0, dayOfWeek: '', startTime: '', endTime: '' } }
+    });
+    const data = watch();
+
+    const load = useCallback(() => {
+        startTransition(() => {
+            getUseCase.execute(new GetClassScheduleCommand(Number(id))).then(res => {
+                if (res.isLeft()) {
+                    toast({ title: 'Error', description: 'No encontrado', variant: 'destructive' });
+                    return;
+                }
+                const m = res.extract() as ClassSchedule;
+                setValue('data.id', m.id);
+                setValue('data.courseId', m.courseId);
+                setValue('data.parallelId', m.parallelId);
+                setValue('data.schoolYearId', m.schoolYearId);
+                setValue('data.subjectId', m.subjectId);
+                setValue('data.dayOfWeek', m.dayOfWeek);
+                setValue('data.startTime', m.startTime);
+                setValue('data.endTime', m.endTime);
+            });
+        });
+    }, [getUseCase, id, setValue]);
+
+    useEffect(() => { load(); }, [load]);
+
+    const onSubmit = () => {
+        startTransition(() => {
+            updateUseCase.execute(new UpdateClassScheduleCommand(data.data)).then(res => {
+                if (res.isLeft()) {
+                    toast({ title: 'Error', description: 'No se pudo actualizar', variant: 'destructive' });
+                    return;
+                }
+                toast({ title: 'Actualizado', description: 'Horario actualizado' });
+            });
+        });
+    };
+    const navigate = useNavigate();
+    const onCancel = () => navigate('/horarios-clase');
+    return <ClassScheduleEditPresenter onSubmit={handleSubmit(onSubmit)} onCancel={onCancel} register={register} errors={errors} isSubmitting={false} />;
+};

--- a/src/scolar/presentation/ui/ClassSchedule/Edit/ClassScheduleEditPresenter.tsx
+++ b/src/scolar/presentation/ui/ClassSchedule/Edit/ClassScheduleEditPresenter.tsx
@@ -1,0 +1,69 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+import { UpdateClassScheduleCommand } from "@/scolar/application/useCases/classSchedules/updateClassScheduleUseCase";
+
+interface Props {
+    onSubmit: () => void;
+    onCancel: () => void;
+    register: UseFormRegister<UpdateClassScheduleCommand>;
+    errors: FieldErrors<UpdateClassScheduleCommand>;
+    isSubmitting: boolean;
+}
+
+export const ClassScheduleEditPresenter = ({ onSubmit, onCancel, register, errors, isSubmitting }: Props) => {
+    return (
+        <Card>
+            <form onSubmit={onSubmit}>
+                <CardHeader>
+                    <CardTitle>Editar Horario</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                    <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                            <Label htmlFor="courseId">Curso ID</Label>
+                            <Input id="courseId" type="number" {...register("data.courseId", { valueAsNumber: true, required: true })} />
+                            {errors.data?.courseId && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="parallelId">Paralelo ID</Label>
+                            <Input id="parallelId" type="number" {...register("data.parallelId", { valueAsNumber: true, required: true })} />
+                            {errors.data?.parallelId && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="schoolYearId">Periodo Lectivo ID</Label>
+                            <Input id="schoolYearId" type="number" {...register("data.schoolYearId", { valueAsNumber: true, required: true })} />
+                            {errors.data?.schoolYearId && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="subjectId">Materia ID</Label>
+                            <Input id="subjectId" type="number" {...register("data.subjectId", { valueAsNumber: true, required: true })} />
+                            {errors.data?.subjectId && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="dayOfWeek">Día de la semana</Label>
+                            <Input id="dayOfWeek" {...register("data.dayOfWeek", { required: true })} />
+                            {errors.data?.dayOfWeek && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="startTime">Hora inicio</Label>
+                            <Input id="startTime" {...register("data.startTime", { required: true })} />
+                            {errors.data?.startTime && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="endTime">Hora fin</Label>
+                            <Input id="endTime" {...register("data.endTime", { required: true })} />
+                            {errors.data?.endTime && <p className="text-red-500 text-sm">Requerido</p>}
+                        </div>
+                    </div>
+                </CardContent>
+                <CardFooter className="flex justify-between">
+                    <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>Cancelar</Button>
+                    <Button type="submit" disabled={isSubmitting}>{isSubmitting ? 'Guardando...' : 'Guardar'}</Button>
+                </CardFooter>
+            </form>
+        </Card>
+    );
+};

--- a/src/scolar/presentation/ui/ClassSchedule/List/ClassScheduleListContainer.tsx
+++ b/src/scolar/presentation/ui/ClassSchedule/List/ClassScheduleListContainer.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useRef, useState, useTransition } from "react";
+import { useInjection } from "inversify-react";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { ClassSchedule } from "@/scolar/domain/entities/classSchedule";
+import { toast } from "@/hooks/use-toast";
+import { ListClassSchedulesUseCase, ListClassSchedulesCommand } from "@/scolar/application/useCases/classSchedules/listClassSchedulesUseCase";
+import { CLASS_SCHEDULE_LIST_USE_CASE } from "@/scolar/domain/symbols/ClassScheduleSymbol";
+import { ClassScheduleListPresenter } from "./ClassScheduleListPresenter";
+import { useNavigate } from "react-router-dom";
+
+export const ClassScheduleListContainer = () => {
+    const listUseCase = useInjection<ListClassSchedulesUseCase>(CLASS_SCHEDULE_LIST_USE_CASE);
+    const [isPending, startTransition] = useTransition();
+    const [command, setCommand] = useState({ page: 1, perPage: 10, where: '', orderBy: [] as string[] });
+    const [result, setResult] = useState<PaginatedResult<ClassSchedule>>({
+        data: [],
+        meta: { currentPage: 1, lastPage: 1, next: null, perPage: 10, prev: null, total: 0 }
+    });
+    const debounceRef = useRef<NodeJS.Timeout | null>(null);
+
+    useEffect(() => {
+        handleLoad();
+    }, [command]);
+
+    const handleLoad = () => {
+        startTransition(() => {
+            listUseCase.execute(new ListClassSchedulesCommand(command.page, command.perPage, command.orderBy, command.where)).then(res => {
+                if (res.isRight()) {
+                    setResult(res.extract() as PaginatedResult<ClassSchedule>);
+                } else {
+                    toast({ title: 'Error', description: 'Error al cargar', variant: 'destructive' });
+                }
+            });
+        });
+    };
+
+    const navigate = useNavigate();
+    const handleAdd = () => navigate('/horarios-clase/nuevo');
+    const handleEdit = (m: ClassSchedule) => navigate(`/horarios-clase/${m.id}`);
+    const handlePaginate = (page: number) => setCommand({ ...command, page });
+    const handleSearch = (term: string) => {
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        debounceRef.current = setTimeout(() => setCommand({ ...command, where: term }), 300);
+    };
+
+    return (
+        <ClassScheduleListPresenter
+            schedules={result}
+            onAdd={handleAdd}
+            onEdit={handleEdit}
+            onDelete={() => handleLoad()}
+            onPaginate={handlePaginate}
+            isPending={isPending}
+            onSearch={handleSearch}
+        />
+    );
+};

--- a/src/scolar/presentation/ui/ClassSchedule/List/ClassScheduleListPresenter.tsx
+++ b/src/scolar/presentation/ui/ClassSchedule/List/ClassScheduleListPresenter.tsx
@@ -1,0 +1,97 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Pagination, PaginationContent, PaginationItem, PaginationLink, PaginationNext, PaginationPrevious } from "@/components/ui/pagination";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Input } from "@/components/ui/input";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { ClassSchedule } from "@/scolar/domain/entities/classSchedule";
+import { Edit, Plus, Search } from "lucide-react";
+import { DeleteClassScheduleContainer } from "../Delete/DeleteClassScheduleContainer";
+
+interface Props {
+    schedules: PaginatedResult<ClassSchedule>;
+    onEdit: (m: ClassSchedule) => void;
+    onDelete: (id: number) => void;
+    onAdd: () => void;
+    onPaginate: (page: number) => void;
+    isPending?: boolean;
+    onSearch: (term: string) => void;
+}
+
+export const ClassScheduleListPresenter = ({ schedules, onEdit, onDelete, onAdd, onPaginate, isPending, onSearch }: Props) => {
+    return (
+        <Card>
+            <CardHeader className="flex flex-row items-center justify-between">
+                <CardTitle>Horarios de Clase</CardTitle>
+                <Button onClick={onAdd} size="sm">
+                    <Plus className="h-4 w-4 mr-2" /> Nuevo
+                </Button>
+            </CardHeader>
+            <CardContent>
+                <div className="relative flex-1 mb-4">
+                    <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+                    <Input type="search" placeholder="Buscar..." className="pl-9" onChange={(e) => onSearch(e.target.value)} />
+                </div>
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead>Curso</TableHead>
+                            <TableHead>Paralelo</TableHead>
+                            <TableHead>Día</TableHead>
+                            <TableHead>Inicio</TableHead>
+                            <TableHead>Fin</TableHead>
+                            <TableHead className="text-right">Acciones</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {isPending && (
+                            <TableRow>
+                                {Array.from({ length: 6 }).map((_, i) => (
+                                    <TableCell key={i}><Skeleton className="h-4 w-full" /></TableCell>
+                                ))}
+                            </TableRow>
+                        )}
+                        {schedules.data.map((m) => (
+                            <TableRow key={m.id}>
+                                <TableCell className="font-medium">{m.courseId}</TableCell>
+                                <TableCell>{m.parallelId}</TableCell>
+                                <TableCell>{m.dayOfWeek}</TableCell>
+                                <TableCell>{m.startTime}</TableCell>
+                                <TableCell>{m.endTime}</TableCell>
+                                <TableCell className="text-right">
+                                    <div className="flex justify-end gap-2">
+                                        <Button variant="ghost" size="icon" onClick={() => onEdit(m)}>
+                                            <Edit className="h-4 w-4" />
+                                            <span className="sr-only">Editar</span>
+                                        </Button>
+                                        <DeleteClassScheduleContainer schedule={m} onConfirm={() => onDelete(m.id)} />
+                                    </div>
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+                <div className="mt-4 flex justify-end items-center gap-4">
+                    <Pagination>
+                        <PaginationContent>
+                            <PaginationItem>
+                                <PaginationPrevious href="#" className={schedules.meta.prev ? 'cursor-pointer' : 'cursor-not-allowed'} onClick={() => onPaginate(schedules.meta.currentPage - 1)} />
+                            </PaginationItem>
+                            {Array.from({ length: schedules.meta.lastPage }, (_, i) => i + 1).map((page) => (
+                                <PaginationItem key={page}>
+                                    <PaginationLink href="#" isActive={page === schedules.meta.currentPage} onClick={() => onPaginate(page)}>
+                                        {page}
+                                    </PaginationLink>
+                                </PaginationItem>
+                            ))}
+                            <PaginationItem>
+                                <PaginationNext href="#" className={schedules.meta.next ? 'cursor-pointer' : 'cursor-not-allowed'} onClick={() => onPaginate(schedules.meta.currentPage + 1)} />
+                            </PaginationItem>
+                        </PaginationContent>
+                    </Pagination>
+                </div>
+            </CardContent>
+        </Card>
+    );
+};

--- a/src/scolar/presentation/ui/MeetingType/Create/MeetingTypeCreateContainer.tsx
+++ b/src/scolar/presentation/ui/MeetingType/Create/MeetingTypeCreateContainer.tsx
@@ -1,0 +1,38 @@
+import { useInjection } from "inversify-react";
+import { MeetingTypeCreatePresenter } from "./MeetingTypeCreatePresenter";
+import { CreateMeetingTypeCommand, CreateMeetingTypeUseCase } from "@/scolar/application/useCases/meetingTypes/createMeetingTypeUseCase";
+import { MEETING_TYPE_CREATE_USE_CASE } from "@/scolar/domain/symbols/MeetingTypeSymbol";
+import { useForm } from "react-hook-form";
+import { toast } from "@/hooks/use-toast";
+import { useTransition } from "react";
+import { useNavigate } from "react-router-dom";
+
+export const MeetingTypeCreateContainer = () => {
+    const usecase = useInjection<CreateMeetingTypeUseCase>(MEETING_TYPE_CREATE_USE_CASE);
+    const [isPending, startTransition] = useTransition();
+    const { register, handleSubmit, formState: { errors } } = useForm<CreateMeetingTypeCommand>({
+        defaultValues: { data: { id: 0, name: '', description: '' } }
+    });
+    const onSubmit = (data: CreateMeetingTypeCommand) => {
+        startTransition(async () => {
+            const res = await usecase.execute(new CreateMeetingTypeCommand(data.data));
+            if (res.isLeft()) {
+                toast({ title: 'Error', description: 'No se pudo crear', variant: 'destructive' });
+                return;
+            }
+            toast({ title: 'Tipo de reunión creado', description: `Tipo ${data.data.name} creado correctamente`, variant: 'success' });
+            navigate('/tipos-reuniones');
+        });
+    };
+    const navigate = useNavigate();
+    const onCancel = () => navigate('/tipos-reuniones');
+    return (
+        <MeetingTypeCreatePresenter
+            onSubmit={handleSubmit(onSubmit)}
+            onCancel={onCancel}
+            register={register}
+            errors={errors}
+            isSubmitting={isPending}
+        />
+    );
+};

--- a/src/scolar/presentation/ui/MeetingType/Create/MeetingTypeCreatePresenter.tsx
+++ b/src/scolar/presentation/ui/MeetingType/Create/MeetingTypeCreatePresenter.tsx
@@ -1,0 +1,42 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+import { CreateMeetingTypeCommand } from "@/scolar/application/useCases/meetingTypes/createMeetingTypeUseCase";
+
+interface Props {
+    onSubmit: () => void;
+    onCancel: () => void;
+    register: UseFormRegister<CreateMeetingTypeCommand>;
+    errors: FieldErrors<CreateMeetingTypeCommand>;
+    isSubmitting: boolean;
+}
+
+export const MeetingTypeCreatePresenter = ({ onSubmit, onCancel, register, errors, isSubmitting }: Props) => {
+    return (
+        <Card>
+            <form onSubmit={onSubmit}>
+                <CardHeader>
+                    <CardTitle>Crear Tipo de Reunión</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                    <div className="space-y-2">
+                        <Label htmlFor="name">Nombre</Label>
+                        <Input id="name" {...register("data.name", { required: true })} />
+                        {errors.data?.name && <p className="text-red-500 text-sm">Requerido</p>}
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="description">Descripción</Label>
+                        <Textarea id="description" {...register("data.description")}></Textarea>
+                    </div>
+                </CardContent>
+                <CardFooter className="flex justify-between">
+                    <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>Cancelar</Button>
+                    <Button type="submit" disabled={isSubmitting}>{isSubmitting ? 'Guardando...' : 'Guardar'}</Button>
+                </CardFooter>
+            </form>
+        </Card>
+    );
+};

--- a/src/scolar/presentation/ui/MeetingType/Delete/DeleteMeetingTypeContainer.tsx
+++ b/src/scolar/presentation/ui/MeetingType/Delete/DeleteMeetingTypeContainer.tsx
@@ -1,0 +1,33 @@
+import { toast } from "@/hooks/use-toast";
+import { useInjection } from "inversify-react";
+import { DeleteMeetingTypePresenter } from "./DeleteMeetingTypePresenter";
+import { MeetingType } from "@/scolar/domain/entities/meetingType";
+import { DeleteMeetingTypeCommand, DeleteMeetingTypeUseCase } from "@/scolar/application/useCases/meetingTypes/deleteMeetingTypeUseCase";
+import { MEETING_TYPE_DELETE_USE_CASE } from "@/scolar/domain/symbols/MeetingTypeSymbol";
+
+interface Props {
+    meetingType: MeetingType;
+    onConfirm: () => void;
+}
+
+export const DeleteMeetingTypeContainer = ({ meetingType, onConfirm }: Props) => {
+    const usecase = useInjection<DeleteMeetingTypeUseCase>(MEETING_TYPE_DELETE_USE_CASE);
+    const handleDelete = async () => {
+        const res = await usecase.execute(new DeleteMeetingTypeCommand(meetingType.id));
+        if (res.isRight()) {
+            toast({
+                title: "Tipo de reunión eliminado",
+                description: "El tipo de reunión ha sido eliminado correctamente",
+                variant: "success",
+            });
+            onConfirm();
+        } else {
+            toast({
+                title: "Error eliminando",
+                description: "No se pudo eliminar el tipo de reunión",
+                variant: "destructive",
+            });
+        }
+    };
+    return <DeleteMeetingTypePresenter meetingType={meetingType} onConfirm={handleDelete} />;
+};

--- a/src/scolar/presentation/ui/MeetingType/Delete/DeleteMeetingTypePresenter.tsx
+++ b/src/scolar/presentation/ui/MeetingType/Delete/DeleteMeetingTypePresenter.tsx
@@ -1,0 +1,42 @@
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { MeetingType } from "@/scolar/domain/entities/meetingType";
+import { Trash2 } from "lucide-react";
+
+interface Props {
+    meetingType: MeetingType;
+    onConfirm: () => void;
+}
+
+export const DeleteMeetingTypePresenter = ({ meetingType, onConfirm }: Props) => {
+    return (
+        <Dialog>
+            <DialogTrigger asChild>
+                <Button variant="ghost" size="icon">
+                    <Trash2 className="h-4 w-4" />
+                    <span className="sr-only">Eliminar</span>
+                </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle>¿Eliminar tipo de reunión?</DialogTitle>
+                    <DialogDescription>
+                        Esta acción no se puede deshacer.
+                        <br />
+                        <strong>{meetingType.name}</strong>
+                    </DialogDescription>
+                </DialogHeader>
+                <DialogFooter className="sm:justify-start">
+                    <DialogClose asChild>
+                        <Button type="button" variant="destructive" onClick={onConfirm}>
+                            Confirmar
+                        </Button>
+                    </DialogClose>
+                    <Button type="button" variant="outline">
+                        Cancelar
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};

--- a/src/scolar/presentation/ui/MeetingType/Edit/MeetingTypeEditContainer.tsx
+++ b/src/scolar/presentation/ui/MeetingType/Edit/MeetingTypeEditContainer.tsx
@@ -1,0 +1,52 @@
+import { startTransition, useCallback, useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { useInjection } from "inversify-react";
+import { toast } from "@/hooks/use-toast";
+import { useNavigate, useParams } from "react-router-dom";
+import { MeetingType } from "@/scolar/domain/entities/meetingType";
+import { GetMeetingTypeUseCase, GetMeetingTypeCommand } from "@/scolar/application/useCases/meetingTypes/getMeetingTypeUseCase";
+import { UpdateMeetingTypeUseCase, UpdateMeetingTypeCommand } from "@/scolar/application/useCases/meetingTypes/updateMeetingTypeUseCase";
+import { MEETING_TYPE_GET_USE_CASE, MEETING_TYPE_UPDATE_USE_CASE } from "@/scolar/domain/symbols/MeetingTypeSymbol";
+import { MeetingTypeEditPresenter } from "./MeetingTypeEditPresenter";
+
+export const MeetingTypeEditContainer = () => {
+    const { id } = useParams<{ id: string }>();
+    const getUseCase = useInjection<GetMeetingTypeUseCase>(MEETING_TYPE_GET_USE_CASE);
+    const updateUseCase = useInjection<UpdateMeetingTypeUseCase>(MEETING_TYPE_UPDATE_USE_CASE);
+    const { register, handleSubmit, formState: { errors }, setValue, watch } = useForm<UpdateMeetingTypeCommand>({
+        defaultValues: { data: { id: Number(id), name: '', description: '' } }
+    });
+    const data = watch();
+
+    const load = useCallback(() => {
+        startTransition(() => {
+            getUseCase.execute(new GetMeetingTypeCommand(Number(id))).then(res => {
+                if (res.isLeft()) {
+                    toast({ title: 'Error', description: 'No encontrado', variant: 'destructive' });
+                    return;
+                }
+                const m = res.extract() as MeetingType;
+                setValue('data.id', m.id);
+                setValue('data.name', m.name);
+                setValue('data.description', m.description);
+            });
+        });
+    }, [getUseCase, id, setValue]);
+
+    useEffect(() => { load(); }, [load]);
+
+    const onSubmit = () => {
+        startTransition(() => {
+            updateUseCase.execute(new UpdateMeetingTypeCommand(data.data)).then(res => {
+                if (res.isLeft()) {
+                    toast({ title: 'Error', description: 'No se pudo actualizar', variant: 'destructive' });
+                    return;
+                }
+                toast({ title: 'Actualizado', description: 'Tipo de reunión actualizado' });
+            });
+        });
+    };
+    const navigate = useNavigate();
+    const onCancel = () => navigate('/tipos-reuniones');
+    return <MeetingTypeEditPresenter onSubmit={handleSubmit(onSubmit)} onCancel={onCancel} register={register} errors={errors} isSubmitting={false} />;
+};

--- a/src/scolar/presentation/ui/MeetingType/Edit/MeetingTypeEditPresenter.tsx
+++ b/src/scolar/presentation/ui/MeetingType/Edit/MeetingTypeEditPresenter.tsx
@@ -1,0 +1,42 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+import { UpdateMeetingTypeCommand } from "@/scolar/application/useCases/meetingTypes/updateMeetingTypeUseCase";
+
+interface Props {
+    onSubmit: () => void;
+    onCancel: () => void;
+    register: UseFormRegister<UpdateMeetingTypeCommand>;
+    errors: FieldErrors<UpdateMeetingTypeCommand>;
+    isSubmitting: boolean;
+}
+
+export const MeetingTypeEditPresenter = ({ onSubmit, onCancel, register, errors, isSubmitting }: Props) => {
+    return (
+        <Card>
+            <form onSubmit={onSubmit}>
+                <CardHeader>
+                    <CardTitle>Editar Tipo de Reunión</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                    <div className="space-y-2">
+                        <Label htmlFor="name">Nombre</Label>
+                        <Input id="name" {...register("data.name", { required: true })} />
+                        {errors.data?.name && <p className="text-red-500 text-sm">Requerido</p>}
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="description">Descripción</Label>
+                        <Textarea id="description" {...register("data.description")}></Textarea>
+                    </div>
+                </CardContent>
+                <CardFooter className="flex justify-between">
+                    <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>Cancelar</Button>
+                    <Button type="submit" disabled={isSubmitting}>{isSubmitting ? 'Guardando...' : 'Guardar'}</Button>
+                </CardFooter>
+            </form>
+        </Card>
+    );
+};

--- a/src/scolar/presentation/ui/MeetingType/List/MeetingTypeListContainer.tsx
+++ b/src/scolar/presentation/ui/MeetingType/List/MeetingTypeListContainer.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useRef, useState, useTransition } from "react";
+import { useInjection } from "inversify-react";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { MeetingType } from "@/scolar/domain/entities/meetingType";
+import { toast } from "@/hooks/use-toast";
+import { ListMeetingTypesUseCase, ListMeetingTypesCommand } from "@/scolar/application/useCases/meetingTypes/listMeetingTypesUseCase";
+import { MEETING_TYPE_LIST_USE_CASE } from "@/scolar/domain/symbols/MeetingTypeSymbol";
+import { MeetingTypeListPresenter } from "./MeetingTypeListPresenter";
+import { useNavigate } from "react-router-dom";
+
+export const MeetingTypeListContainer = () => {
+    const listUseCase = useInjection<ListMeetingTypesUseCase>(MEETING_TYPE_LIST_USE_CASE);
+    const [isPending, startTransition] = useTransition();
+    const [command, setCommand] = useState({ page: 1, perPage: 10, where: '', orderBy: [] as string[] });
+    const [result, setResult] = useState<PaginatedResult<MeetingType>>({
+        data: [],
+        meta: { currentPage: 1, lastPage: 1, next: null, perPage: 10, prev: null, total: 0 }
+    });
+    const debounceRef = useRef<NodeJS.Timeout | null>(null);
+
+    useEffect(() => {
+        handleLoad();
+    }, [command]);
+
+    const handleLoad = () => {
+        startTransition(() => {
+            listUseCase.execute(new ListMeetingTypesCommand(command.page, command.perPage, command.orderBy, command.where)).then(res => {
+                if (res.isRight()) {
+                    setResult(res.extract() as PaginatedResult<MeetingType>);
+                } else {
+                    toast({ title: 'Error', description: 'Error al cargar', variant: 'destructive' });
+                }
+            });
+        });
+    };
+
+    const navigate = useNavigate();
+    const handleAdd = () => navigate('/tipos-reuniones/nuevo');
+    const handleEdit = (m: MeetingType) => navigate(`/tipos-reuniones/${m.id}`);
+    const handlePaginate = (page: number) => setCommand({ ...command, page });
+    const handleSearch = (term: string) => {
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        debounceRef.current = setTimeout(() => setCommand({ ...command, where: term }), 300);
+    };
+
+    return (
+        <MeetingTypeListPresenter
+            meetingTypes={result}
+            onAdd={handleAdd}
+            onEdit={handleEdit}
+            onDelete={() => handleLoad()}
+            onPaginate={handlePaginate}
+            isPending={isPending}
+            onSearch={handleSearch}
+        />
+    );
+};

--- a/src/scolar/presentation/ui/MeetingType/List/MeetingTypeListPresenter.tsx
+++ b/src/scolar/presentation/ui/MeetingType/List/MeetingTypeListPresenter.tsx
@@ -1,0 +1,91 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Pagination, PaginationContent, PaginationItem, PaginationLink, PaginationNext, PaginationPrevious } from "@/components/ui/pagination";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Input } from "@/components/ui/input";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { MeetingType } from "@/scolar/domain/entities/meetingType";
+import { Edit, Plus, Search } from "lucide-react";
+import { DeleteMeetingTypeContainer } from "../Delete/DeleteMeetingTypeContainer";
+
+interface Props {
+    meetingTypes: PaginatedResult<MeetingType>;
+    onEdit: (m: MeetingType) => void;
+    onDelete: (id: number) => void;
+    onAdd: () => void;
+    onPaginate: (page: number) => void;
+    isPending?: boolean;
+    onSearch: (term: string) => void;
+}
+
+export const MeetingTypeListPresenter = ({ meetingTypes, onEdit, onDelete, onAdd, onPaginate, isPending, onSearch }: Props) => {
+    return (
+        <Card>
+            <CardHeader className="flex flex-row items-center justify-between">
+                <CardTitle>Tipos de Reunión</CardTitle>
+                <Button onClick={onAdd} size="sm">
+                    <Plus className="h-4 w-4 mr-2" /> Nuevo
+                </Button>
+            </CardHeader>
+            <CardContent>
+                <div className="relative flex-1 mb-4">
+                    <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+                    <Input type="search" placeholder="Buscar..." className="pl-9" onChange={(e) => onSearch(e.target.value)} />
+                </div>
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead>Nombre</TableHead>
+                            <TableHead>Descripción</TableHead>
+                            <TableHead className="text-right">Acciones</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {isPending && (
+                            <TableRow>
+                                <TableCell colSpan={3}><Skeleton className="h-4 w-full" /></TableCell>
+                                <TableCell colSpan={3}><Skeleton className="h-4 w-full" /></TableCell>
+                                <TableCell colSpan={3}><Skeleton className="h-4 w-full" /></TableCell>
+                            </TableRow>
+                        )}
+                        {meetingTypes.data.map((m) => (
+                            <TableRow key={m.id}>
+                                <TableCell className="font-medium">{m.name}</TableCell>
+                                <TableCell>{m.description || '-'}</TableCell>
+                                <TableCell className="text-right">
+                                    <div className="flex justify-end gap-2">
+                                        <Button variant="ghost" size="icon" onClick={() => onEdit(m)}>
+                                            <Edit className="h-4 w-4" />
+                                            <span className="sr-only">Editar</span>
+                                        </Button>
+                                        <DeleteMeetingTypeContainer meetingType={m} onConfirm={() => onDelete(m.id)} />
+                                    </div>
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+                <div className="mt-4 flex justify-end items-center gap-4">
+                    <Pagination>
+                        <PaginationContent>
+                            <PaginationItem>
+                                <PaginationPrevious href="#" className={meetingTypes.meta.prev ? 'cursor-pointer' : 'cursor-not-allowed'} onClick={() => onPaginate(meetingTypes.meta.currentPage - 1)} />
+                            </PaginationItem>
+                            {Array.from({ length: meetingTypes.meta.lastPage }, (_, i) => i + 1).map((page) => (
+                                <PaginationItem key={page}>
+                                    <PaginationLink href="#" isActive={page === meetingTypes.meta.currentPage} onClick={() => onPaginate(page)}>
+                                        {page}
+                                    </PaginationLink>
+                                </PaginationItem>
+                            ))}
+                            <PaginationItem>
+                                <PaginationNext href="#" className={meetingTypes.meta.next ? 'cursor-pointer' : 'cursor-not-allowed'} onClick={() => onPaginate(meetingTypes.meta.currentPage + 1)} />
+                            </PaginationItem>
+                        </PaginationContent>
+                    </Pagination>
+                </div>
+            </CardContent>
+        </Card>
+    );
+};


### PR DESCRIPTION
## Summary
- add domain, repository, and use-case layers for meeting types, attendance codes, and behavior scales
- implement CRUD UI screens and routing for the new entities
- wire new services and routes into dependency container

## Testing
- `npm run lint` *(fails: Fast refresh only works when a file only exports components)*

------
https://chatgpt.com/codex/tasks/task_e_689543c4a5588330925a7deea6cd593a