### PR TITLE
feat: improve schedule and planning UX

### DIFF
--- a/src/scolar/presentation/ui/AcademicPlanning/Create/AcademicPlanningCreateContainer.tsx
+++ b/src/scolar/presentation/ui/AcademicPlanning/Create/AcademicPlanningCreateContainer.tsx
@@ -1,18 +1,63 @@
+import { useCallback, useEffect, useState, useTransition } from "react";
 import { useInjection } from "inversify-react";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
 import { AcademicPlanningCreatePresenter } from "./AcademicPlanningCreatePresenter";
+import { toast } from "@/hooks/use-toast";
 import { CreateAcademicPlanningCommand, CreateAcademicPlanningUseCase } from "@/scolar/application/useCases/academicPlannings/createAcademicPlanningUseCase";
 import { ACADEMIC_PLANNING_CREATE_USE_CASE } from "@/scolar/domain/symbols/AcademicPlanningSymbol";
-import { useForm } from "react-hook-form";
-import { toast } from "@/hooks/use-toast";
-import { useTransition } from "react";
-import { useNavigate } from "react-router-dom";
+import { COURSE_LIST_USECASE } from "@/scolar/domain/symbols/CourseSymbol";
+import { SUBJECT_LIST_USE_CASE } from "@/scolar/domain/symbols/SubjectSymbol";
+import { SCHOOL_YEAR_LIST_USE_CASE } from "@/scolar/domain/symbols/SchoolYearSymbol";
+import { PARALLEL_GET_LIST_BY_COURSE_USECASE } from "@/scolar/domain/symbols/ParallelSymbol";
+import { ListCoursesUseCase, ListCoursesCommand } from "@/scolar/application/useCases/courses/listCoursesUseCase";
+import { ListSubjectUseCase, ListSubjectCommand } from "@/scolar/application/useCases/subjects/listSubjectsUseCase";
+import { ListSchoolYearUseCase, ListSchoolYearUseCaseCommand } from "@/scolar/application/useCases/schoolYears/listSchoolYearUseCase";
+import { ListParallelByCourseUseCase, ListParallelByCourseUseCaseCommand } from "@/scolar/application/useCases/parallels/listParallelByCourseUseCase";
+import { Course } from "@/scolar/domain/entities/course";
+import { Parallel } from "@/scolar/domain/entities/parallel";
+import { Subject } from "@/scolar/domain/entities/subject";
+import { SchoolYear } from "@/scolar/domain/entities/school_year";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
 
 export const AcademicPlanningCreateContainer = () => {
     const usecase = useInjection<CreateAcademicPlanningUseCase>(ACADEMIC_PLANNING_CREATE_USE_CASE);
+    const listCourses = useInjection<ListCoursesUseCase>(COURSE_LIST_USECASE);
+    const listSubjects = useInjection<ListSubjectUseCase>(SUBJECT_LIST_USE_CASE);
+    const listSchoolYears = useInjection<ListSchoolYearUseCase>(SCHOOL_YEAR_LIST_USE_CASE);
+    const listParallelsByCourse = useInjection<ListParallelByCourseUseCase>(PARALLEL_GET_LIST_BY_COURSE_USECASE);
+
+    const [courses, setCourses] = useState<Course[]>([]);
+    const [parallels, setParallels] = useState<Parallel[]>([]);
+    const [subjects, setSubjects] = useState<Subject[]>([]);
+    const [schoolYears, setSchoolYears] = useState<SchoolYear[]>([]);
+
     const [isPending, startTransition] = useTransition();
-    const { register, handleSubmit, formState: { errors } } = useForm<CreateAcademicPlanningCommand>({
+    const { register, handleSubmit, formState: { errors }, control, watch } = useForm<CreateAcademicPlanningCommand>({
         defaultValues: { data: { id: 0, courseId: 0, parallelId: 0, schoolYearId: 0, subjectId: 0, topic: '', startDate: '', endDate: '', description: '' } }
     });
+    const selectedCourse = watch("data.courseId");
+
+    const fetchInitialData = useCallback(() => {
+        listCourses.execute(new ListCoursesCommand(1, 100, ["id"]))
+            .then(res => res.isRight() && setCourses((res.extract() as PaginatedResult<Course>).data));
+        listSubjects.execute(new ListSubjectCommand(1, 100, ["id"]))
+            .then(res => res.isRight() && setSubjects((res.extract() as PaginatedResult<Subject>).data));
+        listSchoolYears.execute(new ListSchoolYearUseCaseCommand(1, 100, ["id"]))
+            .then(res => res.isRight() && setSchoolYears((res.extract() as PaginatedResult<SchoolYear>).data));
+    }, [listCourses, listSubjects, listSchoolYears]);
+
+    useEffect(() => { fetchInitialData(); }, [fetchInitialData]);
+
+    useEffect(() => {
+        if (!selectedCourse) {
+            setParallels([]);
+            return;
+        }
+        listParallelsByCourse.execute(new ListParallelByCourseUseCaseCommand(Number(selectedCourse), 1, 100, ["id"]))
+            .then(res => res.isRight() && setParallels((res.extract() as PaginatedResult<Parallel>).data));
+    }, [selectedCourse, listParallelsByCourse]);
+
     const navigate = useNavigate();
     const onSubmit = (data: CreateAcademicPlanningCommand) => {
         startTransition(async () => {
@@ -31,8 +76,13 @@ export const AcademicPlanningCreateContainer = () => {
             onSubmit={handleSubmit(onSubmit)}
             onCancel={onCancel}
             register={register}
+            control={control}
             errors={errors}
             isSubmitting={isPending}
+            courses={courses}
+            parallels={parallels}
+            subjects={subjects}
+            schoolYears={schoolYears}
         />
     );
 };

--- a/src/scolar/presentation/ui/AcademicPlanning/Create/AcademicPlanningCreatePresenter.tsx
+++ b/src/scolar/presentation/ui/AcademicPlanning/Create/AcademicPlanningCreatePresenter.tsx
@@ -3,18 +3,39 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/componen
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { FieldErrors, UseFormRegister } from "react-hook-form";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Control, Controller, FieldErrors, UseFormRegister } from "react-hook-form";
 import { CreateAcademicPlanningCommand } from "@/scolar/application/useCases/academicPlannings/createAcademicPlanningUseCase";
+import { Course } from "@/scolar/domain/entities/course";
+import { Parallel } from "@/scolar/domain/entities/parallel";
+import { Subject } from "@/scolar/domain/entities/subject";
+import { SchoolYear } from "@/scolar/domain/entities/school_year";
 
 interface Props {
     onSubmit: () => void;
     onCancel: () => void;
     register: UseFormRegister<CreateAcademicPlanningCommand>;
+    control: Control<CreateAcademicPlanningCommand>;
     errors: FieldErrors<CreateAcademicPlanningCommand>;
     isSubmitting: boolean;
+    courses: Course[];
+    parallels: Parallel[];
+    subjects: Subject[];
+    schoolYears: SchoolYear[];
 }
 
-export const AcademicPlanningCreatePresenter = ({ onSubmit, onCancel, register, errors, isSubmitting }: Props) => {
+export const AcademicPlanningCreatePresenter = ({
+    onSubmit,
+    onCancel,
+    register,
+    control,
+    errors,
+    isSubmitting,
+    courses,
+    parallels,
+    subjects,
+    schoolYears
+}: Props) => {
     return (
         <Card>
             <form onSubmit={onSubmit}>
@@ -24,23 +45,87 @@ export const AcademicPlanningCreatePresenter = ({ onSubmit, onCancel, register, 
                 <CardContent className="space-y-4">
                     <div className="grid grid-cols-2 gap-4">
                         <div className="space-y-2">
-                            <Label htmlFor="courseId">Curso ID</Label>
-                            <Input id="courseId" type="number" {...register("data.courseId", { valueAsNumber: true, required: true })} />
+                            <Label htmlFor="courseId">Curso</Label>
+                            <Controller
+                                name="data.courseId"
+                                control={control}
+                                rules={{ required: true, valueAsNumber: true }}
+                                render={({ field }) => (
+                                    <Select onValueChange={(v) => field.onChange(Number(v))} value={field.value ? String(field.value) : undefined}>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Seleccionar curso" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {courses.map(c => (
+                                                <SelectItem key={c.id} value={String(c.id)}>{c.name}</SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                )}
+                            />
                             {errors.data?.courseId && <p className="text-red-500 text-sm">Requerido</p>}
                         </div>
                         <div className="space-y-2">
-                            <Label htmlFor="parallelId">Paralelo ID</Label>
-                            <Input id="parallelId" type="number" {...register("data.parallelId", { valueAsNumber: true, required: true })} />
+                            <Label htmlFor="parallelId">Paralelo</Label>
+                            <Controller
+                                name="data.parallelId"
+                                control={control}
+                                rules={{ required: true, valueAsNumber: true }}
+                                render={({ field }) => (
+                                    <Select onValueChange={(v) => field.onChange(Number(v))} value={field.value ? String(field.value) : undefined}>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Seleccionar paralelo" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {parallels.map(p => (
+                                                <SelectItem key={p.id} value={String(p.id)}>{p.name}</SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                )}
+                            />
                             {errors.data?.parallelId && <p className="text-red-500 text-sm">Requerido</p>}
                         </div>
                         <div className="space-y-2">
-                            <Label htmlFor="schoolYearId">Periodo Lectivo ID</Label>
-                            <Input id="schoolYearId" type="number" {...register("data.schoolYearId", { valueAsNumber: true, required: true })} />
+                            <Label htmlFor="schoolYearId">Periodo Lectivo</Label>
+                            <Controller
+                                name="data.schoolYearId"
+                                control={control}
+                                rules={{ required: true, valueAsNumber: true }}
+                                render={({ field }) => (
+                                    <Select onValueChange={(v) => field.onChange(Number(v))} value={field.value ? String(field.value) : undefined}>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Seleccionar periodo" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {schoolYears.map(sy => (
+                                                <SelectItem key={sy.id} value={String(sy.id)}>{sy.name}</SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                )}
+                            />
                             {errors.data?.schoolYearId && <p className="text-red-500 text-sm">Requerido</p>}
                         </div>
                         <div className="space-y-2">
-                            <Label htmlFor="subjectId">Materia ID</Label>
-                            <Input id="subjectId" type="number" {...register("data.subjectId", { valueAsNumber: true, required: true })} />
+                            <Label htmlFor="subjectId">Materia</Label>
+                            <Controller
+                                name="data.subjectId"
+                                control={control}
+                                rules={{ required: true, valueAsNumber: true }}
+                                render={({ field }) => (
+                                    <Select onValueChange={(v) => field.onChange(Number(v))} value={field.value ? String(field.value) : undefined}>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Seleccionar materia" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {subjects.map(s => (
+                                                <SelectItem key={s.id} value={String(s.id)}>{s.name}</SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                )}
+                            />
                             {errors.data?.subjectId && <p className="text-red-500 text-sm">Requerido</p>}
                         </div>
                         <div className="space-y-2 col-span-2">
@@ -72,3 +157,4 @@ export const AcademicPlanningCreatePresenter = ({ onSubmit, onCancel, register, 
         </Card>
     );
 };
+

--- a/src/scolar/presentation/ui/AcademicPlanning/Edit/AcademicPlanningEditContainer.tsx
+++ b/src/scolar/presentation/ui/AcademicPlanning/Edit/AcademicPlanningEditContainer.tsx
@@ -1,4 +1,4 @@
-import { startTransition, useCallback, useEffect } from "react";
+import { startTransition, useCallback, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useInjection } from "inversify-react";
 import { toast } from "@/hooks/use-toast";
@@ -8,15 +8,37 @@ import { GetAcademicPlanningUseCase, GetAcademicPlanningCommand } from "@/scolar
 import { UpdateAcademicPlanningUseCase, UpdateAcademicPlanningCommand } from "@/scolar/application/useCases/academicPlannings/updateAcademicPlanningUseCase";
 import { ACADEMIC_PLANNING_GET_USE_CASE, ACADEMIC_PLANNING_UPDATE_USE_CASE } from "@/scolar/domain/symbols/AcademicPlanningSymbol";
 import { AcademicPlanningEditPresenter } from "./AcademicPlanningEditPresenter";
+import { COURSE_LIST_USECASE } from "@/scolar/domain/symbols/CourseSymbol";
+import { SUBJECT_LIST_USE_CASE } from "@/scolar/domain/symbols/SubjectSymbol";
+import { SCHOOL_YEAR_LIST_USE_CASE } from "@/scolar/domain/symbols/SchoolYearSymbol";
+import { PARALLEL_GET_LIST_BY_COURSE_USECASE } from "@/scolar/domain/symbols/ParallelSymbol";
+import { ListCoursesUseCase, ListCoursesCommand } from "@/scolar/application/useCases/courses/listCoursesUseCase";
+import { ListSubjectUseCase, ListSubjectCommand } from "@/scolar/application/useCases/subjects/listSubjectsUseCase";
+import { ListSchoolYearUseCase, ListSchoolYearUseCaseCommand } from "@/scolar/application/useCases/schoolYears/listSchoolYearUseCase";
+import { ListParallelByCourseUseCase, ListParallelByCourseUseCaseCommand } from "@/scolar/application/useCases/parallels/listParallelByCourseUseCase";
+import { Course } from "@/scolar/domain/entities/course";
+import { Parallel } from "@/scolar/domain/entities/parallel";
+import { Subject } from "@/scolar/domain/entities/subject";
+import { SchoolYear } from "@/scolar/domain/entities/school_year";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
 
 export const AcademicPlanningEditContainer = () => {
     const { id } = useParams<{ id: string }>();
     const getUseCase = useInjection<GetAcademicPlanningUseCase>(ACADEMIC_PLANNING_GET_USE_CASE);
     const updateUseCase = useInjection<UpdateAcademicPlanningUseCase>(ACADEMIC_PLANNING_UPDATE_USE_CASE);
-    const { register, handleSubmit, formState: { errors }, setValue, watch } = useForm<UpdateAcademicPlanningCommand>({
+    const listCourses = useInjection<ListCoursesUseCase>(COURSE_LIST_USECASE);
+    const listSubjects = useInjection<ListSubjectUseCase>(SUBJECT_LIST_USE_CASE);
+    const listSchoolYears = useInjection<ListSchoolYearUseCase>(SCHOOL_YEAR_LIST_USE_CASE);
+    const listParallelsByCourse = useInjection<ListParallelByCourseUseCase>(PARALLEL_GET_LIST_BY_COURSE_USECASE);
+    const { register, handleSubmit, formState: { errors }, setValue, watch, control } = useForm<UpdateAcademicPlanningCommand>({
         defaultValues: { data: { id: Number(id), courseId: 0, parallelId: 0, schoolYearId: 0, subjectId: 0, topic: '', startDate: '', endDate: '', description: '' } }
     });
     const data = watch();
+    const [courses, setCourses] = useState<Course[]>([]);
+    const [parallels, setParallels] = useState<Parallel[]>([]);
+    const [subjects, setSubjects] = useState<Subject[]>([]);
+    const [schoolYears, setSchoolYears] = useState<SchoolYear[]>([]);
+    const selectedCourse = watch("data.courseId");
 
     const load = useCallback(() => {
         startTransition(() => {
@@ -39,6 +61,24 @@ export const AcademicPlanningEditContainer = () => {
         });
     }, [getUseCase, id, setValue]);
 
+    useEffect(() => {
+        listCourses.execute(new ListCoursesCommand(1, 100, ["id"]))
+            .then(res => res.isRight() && setCourses((res.extract() as PaginatedResult<Course>).data));
+        listSubjects.execute(new ListSubjectCommand(1, 100, ["id"]))
+            .then(res => res.isRight() && setSubjects((res.extract() as PaginatedResult<Subject>).data));
+        listSchoolYears.execute(new ListSchoolYearUseCaseCommand(1, 100, ["id"]))
+            .then(res => res.isRight() && setSchoolYears((res.extract() as PaginatedResult<SchoolYear>).data));
+    }, [listCourses, listSubjects, listSchoolYears]);
+
+    useEffect(() => {
+        if (!selectedCourse) {
+            setParallels([]);
+            return;
+        }
+        listParallelsByCourse.execute(new ListParallelByCourseUseCaseCommand(Number(selectedCourse), 1, 100, ["id"]))
+            .then(res => res.isRight() && setParallels((res.extract() as PaginatedResult<Parallel>).data));
+    }, [selectedCourse, listParallelsByCourse]);
+
     useEffect(() => { load(); }, [load]);
 
     const onSubmit = () => {
@@ -54,5 +94,18 @@ export const AcademicPlanningEditContainer = () => {
     };
     const navigate = useNavigate();
     const onCancel = () => navigate('/planificaciones-academicas');
-    return <AcademicPlanningEditPresenter onSubmit={handleSubmit(onSubmit)} onCancel={onCancel} register={register} errors={errors} isSubmitting={false} />;
+    return (
+        <AcademicPlanningEditPresenter
+            onSubmit={handleSubmit(onSubmit)}
+            onCancel={onCancel}
+            register={register}
+            control={control}
+            errors={errors}
+            isSubmitting={false}
+            courses={courses}
+            parallels={parallels}
+            subjects={subjects}
+            schoolYears={schoolYears}
+        />
+    );
 };

--- a/src/scolar/presentation/ui/AcademicPlanning/Edit/AcademicPlanningEditPresenter.tsx
+++ b/src/scolar/presentation/ui/AcademicPlanning/Edit/AcademicPlanningEditPresenter.tsx
@@ -3,18 +3,39 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/componen
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { FieldErrors, UseFormRegister } from "react-hook-form";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Control, Controller, FieldErrors, UseFormRegister } from "react-hook-form";
 import { UpdateAcademicPlanningCommand } from "@/scolar/application/useCases/academicPlannings/updateAcademicPlanningUseCase";
+import { Course } from "@/scolar/domain/entities/course";
+import { Parallel } from "@/scolar/domain/entities/parallel";
+import { Subject } from "@/scolar/domain/entities/subject";
+import { SchoolYear } from "@/scolar/domain/entities/school_year";
 
 interface Props {
     onSubmit: () => void;
     onCancel: () => void;
     register: UseFormRegister<UpdateAcademicPlanningCommand>;
+    control: Control<UpdateAcademicPlanningCommand>;
     errors: FieldErrors<UpdateAcademicPlanningCommand>;
     isSubmitting: boolean;
+    courses: Course[];
+    parallels: Parallel[];
+    subjects: Subject[];
+    schoolYears: SchoolYear[];
 }
 
-export const AcademicPlanningEditPresenter = ({ onSubmit, onCancel, register, errors, isSubmitting }: Props) => {
+export const AcademicPlanningEditPresenter = ({
+    onSubmit,
+    onCancel,
+    register,
+    control,
+    errors,
+    isSubmitting,
+    courses,
+    parallels,
+    subjects,
+    schoolYears
+}: Props) => {
     return (
         <Card>
             <form onSubmit={onSubmit}>
@@ -24,23 +45,87 @@ export const AcademicPlanningEditPresenter = ({ onSubmit, onCancel, register, er
                 <CardContent className="space-y-4">
                     <div className="grid grid-cols-2 gap-4">
                         <div className="space-y-2">
-                            <Label htmlFor="courseId">Curso ID</Label>
-                            <Input id="courseId" type="number" {...register("data.courseId", { valueAsNumber: true, required: true })} />
+                            <Label htmlFor="courseId">Curso</Label>
+                            <Controller
+                                name="data.courseId"
+                                control={control}
+                                rules={{ required: true, valueAsNumber: true }}
+                                render={({ field }) => (
+                                    <Select onValueChange={(v) => field.onChange(Number(v))} value={field.value ? String(field.value) : undefined}>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Seleccionar curso" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {courses.map(c => (
+                                                <SelectItem key={c.id} value={String(c.id)}>{c.name}</SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                )}
+                            />
                             {errors.data?.courseId && <p className="text-red-500 text-sm">Requerido</p>}
                         </div>
                         <div className="space-y-2">
-                            <Label htmlFor="parallelId">Paralelo ID</Label>
-                            <Input id="parallelId" type="number" {...register("data.parallelId", { valueAsNumber: true, required: true })} />
+                            <Label htmlFor="parallelId">Paralelo</Label>
+                            <Controller
+                                name="data.parallelId"
+                                control={control}
+                                rules={{ required: true, valueAsNumber: true }}
+                                render={({ field }) => (
+                                    <Select onValueChange={(v) => field.onChange(Number(v))} value={field.value ? String(field.value) : undefined}>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Seleccionar paralelo" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {parallels.map(p => (
+                                                <SelectItem key={p.id} value={String(p.id)}>{p.name}</SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                )}
+                            />
                             {errors.data?.parallelId && <p className="text-red-500 text-sm">Requerido</p>}
                         </div>
                         <div className="space-y-2">
-                            <Label htmlFor="schoolYearId">Periodo Lectivo ID</Label>
-                            <Input id="schoolYearId" type="number" {...register("data.schoolYearId", { valueAsNumber: true, required: true })} />
+                            <Label htmlFor="schoolYearId">Periodo Lectivo</Label>
+                            <Controller
+                                name="data.schoolYearId"
+                                control={control}
+                                rules={{ required: true, valueAsNumber: true }}
+                                render={({ field }) => (
+                                    <Select onValueChange={(v) => field.onChange(Number(v))} value={field.value ? String(field.value) : undefined}>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Seleccionar periodo" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {schoolYears.map(sy => (
+                                                <SelectItem key={sy.id} value={String(sy.id)}>{sy.name}</SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                )}
+                            />
                             {errors.data?.schoolYearId && <p className="text-red-500 text-sm">Requerido</p>}
                         </div>
                         <div className="space-y-2">
-                            <Label htmlFor="subjectId">Materia ID</Label>
-                            <Input id="subjectId" type="number" {...register("data.subjectId", { valueAsNumber: true, required: true })} />
+                            <Label htmlFor="subjectId">Materia</Label>
+                            <Controller
+                                name="data.subjectId"
+                                control={control}
+                                rules={{ required: true, valueAsNumber: true }}
+                                render={({ field }) => (
+                                    <Select onValueChange={(v) => field.onChange(Number(v))} value={field.value ? String(field.value) : undefined}>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Seleccionar materia" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {subjects.map(s => (
+                                                <SelectItem key={s.id} value={String(s.id)}>{s.name}</SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                )}
+                            />
                             {errors.data?.subjectId && <p className="text-red-500 text-sm">Requerido</p>}
                         </div>
                         <div className="space-y-2 col-span-2">
@@ -72,3 +157,4 @@ export const AcademicPlanningEditPresenter = ({ onSubmit, onCancel, register, er
         </Card>
     );
 };
+

--- a/src/scolar/presentation/ui/AcademicPlanning/List/AcademicPlanningListContainer.tsx
+++ b/src/scolar/presentation/ui/AcademicPlanning/List/AcademicPlanningListContainer.tsx
@@ -2,25 +2,50 @@ import { useEffect, useRef, useState, useTransition } from "react";
 import { useInjection } from "inversify-react";
 import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
 import { AcademicPlanning } from "@/scolar/domain/entities/academicPlanning";
+import { Course } from "@/scolar/domain/entities/course";
+import { Parallel } from "@/scolar/domain/entities/parallel";
+import { Subject } from "@/scolar/domain/entities/subject";
 import { toast } from "@/hooks/use-toast";
 import { ListAcademicPlanningsUseCase, ListAcademicPlanningsCommand } from "@/scolar/application/useCases/academicPlannings/listAcademicPlanningsUseCase";
 import { ACADEMIC_PLANNING_LIST_USE_CASE } from "@/scolar/domain/symbols/AcademicPlanningSymbol";
 import { AcademicPlanningListPresenter } from "./AcademicPlanningListPresenter";
 import { useNavigate } from "react-router-dom";
+import { COURSE_LIST_USECASE } from "@/scolar/domain/symbols/CourseSymbol";
+import { PARALLEL_LIST_USECASE } from "@/scolar/domain/symbols/ParallelSymbol";
+import { SUBJECT_LIST_USE_CASE } from "@/scolar/domain/symbols/SubjectSymbol";
+import { ListCoursesUseCase, ListCoursesCommand } from "@/scolar/application/useCases/courses/listCoursesUseCase";
+import { ListParallelUseCase, ListParallelUseCaseCommand } from "@/scolar/application/useCases/parallels/listParallelUseCase";
+import { ListSubjectUseCase, ListSubjectCommand } from "@/scolar/application/useCases/subjects/listSubjectsUseCase";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
 
 export const AcademicPlanningListContainer = () => {
     const listUseCase = useInjection<ListAcademicPlanningsUseCase>(ACADEMIC_PLANNING_LIST_USE_CASE);
+    const listCourses = useInjection<ListCoursesUseCase>(COURSE_LIST_USECASE);
+    const listParallels = useInjection<ListParallelUseCase>(PARALLEL_LIST_USECASE);
+    const listSubjects = useInjection<ListSubjectUseCase>(SUBJECT_LIST_USE_CASE);
     const [isPending, startTransition] = useTransition();
     const [command, setCommand] = useState({ page: 1, perPage: 10, where: '', orderBy: [] as string[] });
     const [result, setResult] = useState<PaginatedResult<AcademicPlanning>>({
         data: [],
         meta: { currentPage: 1, lastPage: 1, next: null, perPage: 10, prev: null, total: 0 }
     });
+    const [courses, setCourses] = useState<Course[]>([]);
+    const [parallels, setParallels] = useState<Parallel[]>([]);
+    const [subjects, setSubjects] = useState<Subject[]>([]);
     const debounceRef = useRef<NodeJS.Timeout | null>(null);
 
     useEffect(() => {
         handleLoad();
     }, [command]);
+
+    useEffect(() => {
+        listCourses.execute(new ListCoursesCommand(1, 100, ["id"]))
+            .then(res => res.isRight() && setCourses((res.extract() as PaginatedResult<Course>).data));
+        listParallels.execute(new ListParallelUseCaseCommand(1, 100, ["id"]))
+            .then(res => res.isRight() && setParallels((res.extract() as PaginatedResult<Parallel>).data));
+        listSubjects.execute(new ListSubjectCommand(1, 100, ["id"]))
+            .then(res => res.isRight() && setSubjects((res.extract() as PaginatedResult<Subject>).data));
+    }, [listCourses, listParallels, listSubjects]);
 
     const handleLoad = () => {
         startTransition(() => {
@@ -52,6 +77,9 @@ export const AcademicPlanningListContainer = () => {
             onPaginate={handlePaginate}
             isPending={isPending}
             onSearch={handleSearch}
+            courses={courses}
+            parallels={parallels}
+            subjects={subjects}
         />
     );
 };

--- a/src/scolar/presentation/ui/AcademicPlanning/List/AcademicPlanningListPresenter.tsx
+++ b/src/scolar/presentation/ui/AcademicPlanning/List/AcademicPlanningListPresenter.tsx
@@ -6,7 +6,11 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Input } from "@/components/ui/input";
 import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
 import { AcademicPlanning } from "@/scolar/domain/entities/academicPlanning";
+import { Course } from "@/scolar/domain/entities/course";
+import { Parallel } from "@/scolar/domain/entities/parallel";
+import { Subject } from "@/scolar/domain/entities/subject";
 import { Edit, Plus, Search } from "lucide-react";
+import { format, parseISO } from "date-fns";
 import { DeleteAcademicPlanningContainer } from "../Delete/DeleteAcademicPlanningContainer";
 
 interface Props {
@@ -17,9 +21,15 @@ interface Props {
     onPaginate: (page: number) => void;
     isPending?: boolean;
     onSearch: (term: string) => void;
+    courses: Course[];
+    parallels: Parallel[];
+    subjects: Subject[];
 }
 
-export const AcademicPlanningListPresenter = ({ plannings, onEdit, onDelete, onAdd, onPaginate, isPending, onSearch }: Props) => {
+export const AcademicPlanningListPresenter = ({ plannings, onEdit, onDelete, onAdd, onPaginate, isPending, onSearch, courses, parallels, subjects }: Props) => {
+    const getCourseName = (id: number) => courses.find(c => c.id === id)?.name || '';
+    const getParallelName = (id: number) => parallels.find(p => p.id === id)?.name || '';
+    const getSubjectName = (id: number) => subjects.find(s => s.id === id)?.name || '';
     return (
         <Card>
             <CardHeader className="flex flex-row items-center justify-between">
@@ -38,6 +48,7 @@ export const AcademicPlanningListPresenter = ({ plannings, onEdit, onDelete, onA
                         <TableRow>
                             <TableHead>Curso</TableHead>
                             <TableHead>Paralelo</TableHead>
+                            <TableHead>Materia</TableHead>
                             <TableHead>Tema</TableHead>
                             <TableHead>Inicio</TableHead>
                             <TableHead>Fin</TableHead>
@@ -54,11 +65,12 @@ export const AcademicPlanningListPresenter = ({ plannings, onEdit, onDelete, onA
                         )}
                         {plannings.data.map((m) => (
                             <TableRow key={m.id}>
-                                <TableCell className="font-medium">{m.courseId}</TableCell>
-                                <TableCell>{m.parallelId}</TableCell>
+                                <TableCell className="font-medium">{getCourseName(m.courseId)}</TableCell>
+                                <TableCell>{getParallelName(m.parallelId)}</TableCell>
+                                <TableCell>{getSubjectName(m.subjectId)}</TableCell>
                                 <TableCell>{m.topic}</TableCell>
-                                <TableCell>{m.startDate}</TableCell>
-                                <TableCell>{m.endDate}</TableCell>
+                                <TableCell>{format(parseISO(m.startDate), 'dd/MM/yyyy')}</TableCell>
+                                <TableCell>{format(parseISO(m.endDate), 'dd/MM/yyyy')}</TableCell>
                                 <TableCell className="text-right">
                                     <div className="flex justify-end gap-2">
                                         <Button variant="ghost" size="icon" onClick={() => onEdit(m)}>

--- a/src/scolar/presentation/ui/ClassSchedule/Create/ClassScheduleCreateContainer.tsx
+++ b/src/scolar/presentation/ui/ClassSchedule/Create/ClassScheduleCreateContainer.tsx
@@ -1,18 +1,80 @@
+import { useCallback, useEffect, useTransition, useState } from "react";
 import { useInjection } from "inversify-react";
-import { ClassScheduleCreatePresenter } from "./ClassScheduleCreatePresenter";
-import { CreateClassScheduleCommand, CreateClassScheduleUseCase } from "@/scolar/application/useCases/classSchedules/createClassScheduleUseCase";
-import { CLASS_SCHEDULE_CREATE_USE_CASE } from "@/scolar/domain/symbols/ClassScheduleSymbol";
 import { useForm } from "react-hook-form";
-import { toast } from "@/hooks/use-toast";
-import { useTransition } from "react";
 import { useNavigate } from "react-router-dom";
+
+import { ClassScheduleCreatePresenter } from "./ClassScheduleCreatePresenter";
+import { toast } from "@/hooks/use-toast";
+import {
+    CreateClassScheduleCommand,
+    CreateClassScheduleUseCase
+} from "@/scolar/application/useCases/classSchedules/createClassScheduleUseCase";
+import { CLASS_SCHEDULE_CREATE_USE_CASE } from "@/scolar/domain/symbols/ClassScheduleSymbol";
+import { COURSE_LIST_USECASE } from "@/scolar/domain/symbols/CourseSymbol";
+import { SUBJECT_LIST_USE_CASE } from "@/scolar/domain/symbols/SubjectSymbol";
+import {
+    ListSchoolYearUseCase,
+    ListSchoolYearUseCaseCommand
+} from "@/scolar/application/useCases/schoolYears/listSchoolYearUseCase";
+import { SCHOOL_YEAR_LIST_USE_CASE } from "@/scolar/domain/symbols/SchoolYearSymbol";
+import {
+    ListCoursesUseCase,
+    ListCoursesCommand
+} from "@/scolar/application/useCases/courses/listCoursesUseCase";
+import {
+    ListSubjectUseCase,
+    ListSubjectCommand
+} from "@/scolar/application/useCases/subjects/listSubjectsUseCase";
+import {
+    ListParallelByCourseUseCase,
+    ListParallelByCourseUseCaseCommand
+} from "@/scolar/application/useCases/parallels/listParallelByCourseUseCase";
+import { PARALLEL_GET_LIST_BY_COURSE_USECASE } from "@/scolar/domain/symbols/ParallelSymbol";
+import { Course } from "@/scolar/domain/entities/course";
+import { Parallel } from "@/scolar/domain/entities/parallel";
+import { Subject } from "@/scolar/domain/entities/subject";
+import { SchoolYear } from "@/scolar/domain/entities/school_year";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
 
 export const ClassScheduleCreateContainer = () => {
     const usecase = useInjection<CreateClassScheduleUseCase>(CLASS_SCHEDULE_CREATE_USE_CASE);
+    const listCourses = useInjection<ListCoursesUseCase>(COURSE_LIST_USECASE);
+    const listSubjects = useInjection<ListSubjectUseCase>(SUBJECT_LIST_USE_CASE);
+    const listSchoolYears = useInjection<ListSchoolYearUseCase>(SCHOOL_YEAR_LIST_USE_CASE);
+    const listParallelsByCourse = useInjection<ListParallelByCourseUseCase>(PARALLEL_GET_LIST_BY_COURSE_USECASE);
+
+    const [courses, setCourses] = useState<Course[]>([]);
+    const [parallels, setParallels] = useState<Parallel[]>([]);
+    const [subjects, setSubjects] = useState<Subject[]>([]);
+    const [schoolYears, setSchoolYears] = useState<SchoolYear[]>([]);
+
     const [isPending, startTransition] = useTransition();
-    const { register, handleSubmit, formState: { errors } } = useForm<CreateClassScheduleCommand>({
+    const { register, handleSubmit, formState: { errors }, control, watch } = useForm<CreateClassScheduleCommand>({
         defaultValues: { data: { id: 0, courseId: 0, parallelId: 0, schoolYearId: 0, subjectId: 0, dayOfWeek: '', startTime: '', endTime: '' } }
     });
+
+    const selectedCourse = watch("data.courseId");
+
+    const fetchInitialData = useCallback(() => {
+        listCourses.execute(new ListCoursesCommand(1, 100, ["id"]))
+            .then(res => res.isRight() && setCourses((res.extract() as PaginatedResult<Course>).data));
+        listSubjects.execute(new ListSubjectCommand(1, 100, ["id"]))
+            .then(res => res.isRight() && setSubjects((res.extract() as PaginatedResult<Subject>).data));
+        listSchoolYears.execute(new ListSchoolYearUseCaseCommand(1, 100, ["id"]))
+            .then(res => res.isRight() && setSchoolYears((res.extract() as PaginatedResult<SchoolYear>).data));
+    }, [listCourses, listSubjects, listSchoolYears]);
+
+    useEffect(() => { fetchInitialData(); }, [fetchInitialData]);
+
+    useEffect(() => {
+        if (!selectedCourse) {
+            setParallels([]);
+            return;
+        }
+        listParallelsByCourse.execute(new ListParallelByCourseUseCaseCommand(Number(selectedCourse), 1, 100, ["id"]))
+            .then(res => res.isRight() && setParallels((res.extract() as PaginatedResult<Parallel>).data));
+    }, [selectedCourse, listParallelsByCourse]);
+
     const navigate = useNavigate();
     const onSubmit = (data: CreateClassScheduleCommand) => {
         startTransition(async () => {
@@ -33,6 +95,11 @@ export const ClassScheduleCreateContainer = () => {
             register={register}
             errors={errors}
             isSubmitting={isPending}
+            control={control}
+            courses={courses}
+            parallels={parallels}
+            subjects={subjects}
+            schoolYears={schoolYears}
         />
     );
 };

--- a/src/scolar/presentation/ui/ClassSchedule/Create/ClassScheduleCreatePresenter.tsx
+++ b/src/scolar/presentation/ui/ClassSchedule/Create/ClassScheduleCreatePresenter.tsx
@@ -2,18 +2,48 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { FieldErrors, UseFormRegister } from "react-hook-form";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Control, Controller, FieldErrors, UseFormRegister } from "react-hook-form";
 import { CreateClassScheduleCommand } from "@/scolar/application/useCases/classSchedules/createClassScheduleUseCase";
+import { Course } from "@/scolar/domain/entities/course";
+import { Parallel } from "@/scolar/domain/entities/parallel";
+import { Subject } from "@/scolar/domain/entities/subject";
+import { SchoolYear } from "@/scolar/domain/entities/school_year";
 
 interface Props {
     onSubmit: () => void;
     onCancel: () => void;
     register: UseFormRegister<CreateClassScheduleCommand>;
+    control: Control<CreateClassScheduleCommand>;
     errors: FieldErrors<CreateClassScheduleCommand>;
     isSubmitting: boolean;
+    courses: Course[];
+    parallels: Parallel[];
+    subjects: Subject[];
+    schoolYears: SchoolYear[];
 }
 
-export const ClassScheduleCreatePresenter = ({ onSubmit, onCancel, register, errors, isSubmitting }: Props) => {
+const days = [
+    { value: "lunes", label: "Lunes" },
+    { value: "martes", label: "Martes" },
+    { value: "miercoles", label: "Miércoles" },
+    { value: "jueves", label: "Jueves" },
+    { value: "viernes", label: "Viernes" },
+    { value: "sabado", label: "Sábado" },
+];
+
+export const ClassScheduleCreatePresenter = ({
+    onSubmit,
+    onCancel,
+    register,
+    control,
+    errors,
+    isSubmitting,
+    courses,
+    parallels,
+    subjects,
+    schoolYears
+}: Props) => {
     return (
         <Card>
             <form onSubmit={onSubmit}>
@@ -23,38 +53,118 @@ export const ClassScheduleCreatePresenter = ({ onSubmit, onCancel, register, err
                 <CardContent className="space-y-4">
                     <div className="grid grid-cols-2 gap-4">
                         <div className="space-y-2">
-                            <Label htmlFor="courseId">Curso ID</Label>
-                            <Input id="courseId" type="number" {...register("data.courseId", { valueAsNumber: true, required: true })} />
+                            <Label htmlFor="courseId">Curso</Label>
+                            <Controller
+                                name="data.courseId"
+                                control={control}
+                                rules={{ required: true, valueAsNumber: true }}
+                                render={({ field }) => (
+                                    <Select onValueChange={(v) => field.onChange(Number(v))} value={field.value ? String(field.value) : undefined}>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Seleccionar curso" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {courses.map(c => (
+                                                <SelectItem key={c.id} value={String(c.id)}>{c.name}</SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                )}
+                            />
                             {errors.data?.courseId && <p className="text-red-500 text-sm">Requerido</p>}
                         </div>
                         <div className="space-y-2">
-                            <Label htmlFor="parallelId">Paralelo ID</Label>
-                            <Input id="parallelId" type="number" {...register("data.parallelId", { valueAsNumber: true, required: true })} />
+                            <Label htmlFor="parallelId">Paralelo</Label>
+                            <Controller
+                                name="data.parallelId"
+                                control={control}
+                                rules={{ required: true, valueAsNumber: true }}
+                                render={({ field }) => (
+                                    <Select onValueChange={(v) => field.onChange(Number(v))} value={field.value ? String(field.value) : undefined}>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Seleccionar paralelo" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {parallels.map(p => (
+                                                <SelectItem key={p.id} value={String(p.id)}>{p.name}</SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                )}
+                            />
                             {errors.data?.parallelId && <p className="text-red-500 text-sm">Requerido</p>}
                         </div>
                         <div className="space-y-2">
-                            <Label htmlFor="schoolYearId">Periodo Lectivo ID</Label>
-                            <Input id="schoolYearId" type="number" {...register("data.schoolYearId", { valueAsNumber: true, required: true })} />
+                            <Label htmlFor="schoolYearId">Periodo Lectivo</Label>
+                            <Controller
+                                name="data.schoolYearId"
+                                control={control}
+                                rules={{ required: true, valueAsNumber: true }}
+                                render={({ field }) => (
+                                    <Select onValueChange={(v) => field.onChange(Number(v))} value={field.value ? String(field.value) : undefined}>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Seleccionar periodo" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {schoolYears.map(sy => (
+                                                <SelectItem key={sy.id} value={String(sy.id)}>{sy.name}</SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                )}
+                            />
                             {errors.data?.schoolYearId && <p className="text-red-500 text-sm">Requerido</p>}
                         </div>
                         <div className="space-y-2">
-                            <Label htmlFor="subjectId">Materia ID</Label>
-                            <Input id="subjectId" type="number" {...register("data.subjectId", { valueAsNumber: true, required: true })} />
+                            <Label htmlFor="subjectId">Materia</Label>
+                            <Controller
+                                name="data.subjectId"
+                                control={control}
+                                rules={{ required: true, valueAsNumber: true }}
+                                render={({ field }) => (
+                                    <Select onValueChange={(v) => field.onChange(Number(v))} value={field.value ? String(field.value) : undefined}>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Seleccionar materia" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {subjects.map(s => (
+                                                <SelectItem key={s.id} value={String(s.id)}>{s.name}</SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                )}
+                            />
                             {errors.data?.subjectId && <p className="text-red-500 text-sm">Requerido</p>}
                         </div>
                         <div className="space-y-2">
                             <Label htmlFor="dayOfWeek">Día de la semana</Label>
-                            <Input id="dayOfWeek" {...register("data.dayOfWeek", { required: true })} />
+                            <Controller
+                                name="data.dayOfWeek"
+                                control={control}
+                                rules={{ required: true }}
+                                render={({ field }) => (
+                                    <Select onValueChange={field.onChange} value={field.value}>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Seleccionar día" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {days.map(d => (
+                                                <SelectItem key={d.value} value={d.value}>{d.label}</SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                )}
+                            />
                             {errors.data?.dayOfWeek && <p className="text-red-500 text-sm">Requerido</p>}
                         </div>
                         <div className="space-y-2">
                             <Label htmlFor="startTime">Hora inicio</Label>
-                            <Input id="startTime" {...register("data.startTime", { required: true })} />
+                            <Input id="startTime" type="time" {...register("data.startTime", { required: true })} />
                             {errors.data?.startTime && <p className="text-red-500 text-sm">Requerido</p>}
                         </div>
                         <div className="space-y-2">
                             <Label htmlFor="endTime">Hora fin</Label>
-                            <Input id="endTime" {...register("data.endTime", { required: true })} />
+                            <Input id="endTime" type="time" {...register("data.endTime", { required: true })} />
                             {errors.data?.endTime && <p className="text-red-500 text-sm">Requerido</p>}
                         </div>
                     </div>
@@ -67,3 +177,4 @@ export const ClassScheduleCreatePresenter = ({ onSubmit, onCancel, register, err
         </Card>
     );
 };
+

--- a/src/scolar/presentation/ui/ClassSchedule/Edit/ClassScheduleEditContainer.tsx
+++ b/src/scolar/presentation/ui/ClassSchedule/Edit/ClassScheduleEditContainer.tsx
@@ -1,4 +1,4 @@
-import { startTransition, useCallback, useEffect } from "react";
+import { startTransition, useCallback, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useInjection } from "inversify-react";
 import { toast } from "@/hooks/use-toast";
@@ -8,15 +8,37 @@ import { GetClassScheduleUseCase, GetClassScheduleCommand } from "@/scolar/appli
 import { UpdateClassScheduleUseCase, UpdateClassScheduleCommand } from "@/scolar/application/useCases/classSchedules/updateClassScheduleUseCase";
 import { CLASS_SCHEDULE_GET_USE_CASE, CLASS_SCHEDULE_UPDATE_USE_CASE } from "@/scolar/domain/symbols/ClassScheduleSymbol";
 import { ClassScheduleEditPresenter } from "./ClassScheduleEditPresenter";
+import { COURSE_LIST_USECASE } from "@/scolar/domain/symbols/CourseSymbol";
+import { SUBJECT_LIST_USE_CASE } from "@/scolar/domain/symbols/SubjectSymbol";
+import { SCHOOL_YEAR_LIST_USE_CASE } from "@/scolar/domain/symbols/SchoolYearSymbol";
+import { PARALLEL_GET_LIST_BY_COURSE_USECASE } from "@/scolar/domain/symbols/ParallelSymbol";
+import { ListCoursesUseCase, ListCoursesCommand } from "@/scolar/application/useCases/courses/listCoursesUseCase";
+import { ListSubjectUseCase, ListSubjectCommand } from "@/scolar/application/useCases/subjects/listSubjectsUseCase";
+import { ListSchoolYearUseCase, ListSchoolYearUseCaseCommand } from "@/scolar/application/useCases/schoolYears/listSchoolYearUseCase";
+import { ListParallelByCourseUseCase, ListParallelByCourseUseCaseCommand } from "@/scolar/application/useCases/parallels/listParallelByCourseUseCase";
+import { Course } from "@/scolar/domain/entities/course";
+import { Parallel } from "@/scolar/domain/entities/parallel";
+import { Subject } from "@/scolar/domain/entities/subject";
+import { SchoolYear } from "@/scolar/domain/entities/school_year";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
 
 export const ClassScheduleEditContainer = () => {
     const { id } = useParams<{ id: string }>();
     const getUseCase = useInjection<GetClassScheduleUseCase>(CLASS_SCHEDULE_GET_USE_CASE);
     const updateUseCase = useInjection<UpdateClassScheduleUseCase>(CLASS_SCHEDULE_UPDATE_USE_CASE);
-    const { register, handleSubmit, formState: { errors }, setValue, watch } = useForm<UpdateClassScheduleCommand>({
+    const listCourses = useInjection<ListCoursesUseCase>(COURSE_LIST_USECASE);
+    const listSubjects = useInjection<ListSubjectUseCase>(SUBJECT_LIST_USE_CASE);
+    const listSchoolYears = useInjection<ListSchoolYearUseCase>(SCHOOL_YEAR_LIST_USE_CASE);
+    const listParallelsByCourse = useInjection<ListParallelByCourseUseCase>(PARALLEL_GET_LIST_BY_COURSE_USECASE);
+    const { register, handleSubmit, formState: { errors }, setValue, watch, control } = useForm<UpdateClassScheduleCommand>({
         defaultValues: { data: { id: Number(id), courseId: 0, parallelId: 0, schoolYearId: 0, subjectId: 0, dayOfWeek: '', startTime: '', endTime: '' } }
     });
     const data = watch();
+    const [courses, setCourses] = useState<Course[]>([]);
+    const [subjects, setSubjects] = useState<Subject[]>([]);
+    const [schoolYears, setSchoolYears] = useState<SchoolYear[]>([]);
+    const [parallels, setParallels] = useState<Parallel[]>([]);
+    const selectedCourse = watch("data.courseId");
 
     const load = useCallback(() => {
         startTransition(() => {
@@ -38,6 +60,24 @@ export const ClassScheduleEditContainer = () => {
         });
     }, [getUseCase, id, setValue]);
 
+    useEffect(() => {
+        listCourses.execute(new ListCoursesCommand(1, 100, ["id"]))
+            .then(res => res.isRight() && setCourses((res.extract() as PaginatedResult<Course>).data));
+        listSubjects.execute(new ListSubjectCommand(1, 100, ["id"]))
+            .then(res => res.isRight() && setSubjects((res.extract() as PaginatedResult<Subject>).data));
+        listSchoolYears.execute(new ListSchoolYearUseCaseCommand(1, 100, ["id"]))
+            .then(res => res.isRight() && setSchoolYears((res.extract() as PaginatedResult<SchoolYear>).data));
+    }, [listCourses, listSubjects, listSchoolYears]);
+
+    useEffect(() => {
+        if (!selectedCourse) {
+            setParallels([]);
+            return;
+        }
+        listParallelsByCourse.execute(new ListParallelByCourseUseCaseCommand(Number(selectedCourse), 1, 100, ["id"]))
+            .then(res => res.isRight() && setParallels((res.extract() as PaginatedResult<Parallel>).data));
+    }, [selectedCourse, listParallelsByCourse]);
+
     useEffect(() => { load(); }, [load]);
 
     const onSubmit = () => {
@@ -53,5 +93,18 @@ export const ClassScheduleEditContainer = () => {
     };
     const navigate = useNavigate();
     const onCancel = () => navigate('/horarios-clase');
-    return <ClassScheduleEditPresenter onSubmit={handleSubmit(onSubmit)} onCancel={onCancel} register={register} errors={errors} isSubmitting={false} />;
+    return (
+        <ClassScheduleEditPresenter
+            onSubmit={handleSubmit(onSubmit)}
+            onCancel={onCancel}
+            register={register}
+            control={control}
+            errors={errors}
+            isSubmitting={false}
+            courses={courses}
+            parallels={parallels}
+            subjects={subjects}
+            schoolYears={schoolYears}
+        />
+    );
 };

--- a/src/scolar/presentation/ui/ClassSchedule/Edit/ClassScheduleEditPresenter.tsx
+++ b/src/scolar/presentation/ui/ClassSchedule/Edit/ClassScheduleEditPresenter.tsx
@@ -2,18 +2,48 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { FieldErrors, UseFormRegister } from "react-hook-form";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Control, Controller, FieldErrors, UseFormRegister } from "react-hook-form";
 import { UpdateClassScheduleCommand } from "@/scolar/application/useCases/classSchedules/updateClassScheduleUseCase";
+import { Course } from "@/scolar/domain/entities/course";
+import { Parallel } from "@/scolar/domain/entities/parallel";
+import { Subject } from "@/scolar/domain/entities/subject";
+import { SchoolYear } from "@/scolar/domain/entities/school_year";
 
 interface Props {
     onSubmit: () => void;
     onCancel: () => void;
     register: UseFormRegister<UpdateClassScheduleCommand>;
+    control: Control<UpdateClassScheduleCommand>;
     errors: FieldErrors<UpdateClassScheduleCommand>;
     isSubmitting: boolean;
+    courses: Course[];
+    parallels: Parallel[];
+    subjects: Subject[];
+    schoolYears: SchoolYear[];
 }
 
-export const ClassScheduleEditPresenter = ({ onSubmit, onCancel, register, errors, isSubmitting }: Props) => {
+const days = [
+    { value: "lunes", label: "Lunes" },
+    { value: "martes", label: "Martes" },
+    { value: "miercoles", label: "Miércoles" },
+    { value: "jueves", label: "Jueves" },
+    { value: "viernes", label: "Viernes" },
+    { value: "sabado", label: "Sábado" },
+];
+
+export const ClassScheduleEditPresenter = ({
+    onSubmit,
+    onCancel,
+    register,
+    control,
+    errors,
+    isSubmitting,
+    courses,
+    parallels,
+    subjects,
+    schoolYears
+}: Props) => {
     return (
         <Card>
             <form onSubmit={onSubmit}>
@@ -23,38 +53,118 @@ export const ClassScheduleEditPresenter = ({ onSubmit, onCancel, register, error
                 <CardContent className="space-y-4">
                     <div className="grid grid-cols-2 gap-4">
                         <div className="space-y-2">
-                            <Label htmlFor="courseId">Curso ID</Label>
-                            <Input id="courseId" type="number" {...register("data.courseId", { valueAsNumber: true, required: true })} />
+                            <Label htmlFor="courseId">Curso</Label>
+                            <Controller
+                                name="data.courseId"
+                                control={control}
+                                rules={{ required: true, valueAsNumber: true }}
+                                render={({ field }) => (
+                                    <Select onValueChange={(v) => field.onChange(Number(v))} value={field.value ? String(field.value) : undefined}>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Seleccionar curso" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {courses.map(c => (
+                                                <SelectItem key={c.id} value={String(c.id)}>{c.name}</SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                )}
+                            />
                             {errors.data?.courseId && <p className="text-red-500 text-sm">Requerido</p>}
                         </div>
                         <div className="space-y-2">
-                            <Label htmlFor="parallelId">Paralelo ID</Label>
-                            <Input id="parallelId" type="number" {...register("data.parallelId", { valueAsNumber: true, required: true })} />
+                            <Label htmlFor="parallelId">Paralelo</Label>
+                            <Controller
+                                name="data.parallelId"
+                                control={control}
+                                rules={{ required: true, valueAsNumber: true }}
+                                render={({ field }) => (
+                                    <Select onValueChange={(v) => field.onChange(Number(v))} value={field.value ? String(field.value) : undefined}>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Seleccionar paralelo" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {parallels.map(p => (
+                                                <SelectItem key={p.id} value={String(p.id)}>{p.name}</SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                )}
+                            />
                             {errors.data?.parallelId && <p className="text-red-500 text-sm">Requerido</p>}
                         </div>
                         <div className="space-y-2">
-                            <Label htmlFor="schoolYearId">Periodo Lectivo ID</Label>
-                            <Input id="schoolYearId" type="number" {...register("data.schoolYearId", { valueAsNumber: true, required: true })} />
+                            <Label htmlFor="schoolYearId">Periodo Lectivo</Label>
+                            <Controller
+                                name="data.schoolYearId"
+                                control={control}
+                                rules={{ required: true, valueAsNumber: true }}
+                                render={({ field }) => (
+                                    <Select onValueChange={(v) => field.onChange(Number(v))} value={field.value ? String(field.value) : undefined}>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Seleccionar periodo" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {schoolYears.map(sy => (
+                                                <SelectItem key={sy.id} value={String(sy.id)}>{sy.name}</SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                )}
+                            />
                             {errors.data?.schoolYearId && <p className="text-red-500 text-sm">Requerido</p>}
                         </div>
                         <div className="space-y-2">
-                            <Label htmlFor="subjectId">Materia ID</Label>
-                            <Input id="subjectId" type="number" {...register("data.subjectId", { valueAsNumber: true, required: true })} />
+                            <Label htmlFor="subjectId">Materia</Label>
+                            <Controller
+                                name="data.subjectId"
+                                control={control}
+                                rules={{ required: true, valueAsNumber: true }}
+                                render={({ field }) => (
+                                    <Select onValueChange={(v) => field.onChange(Number(v))} value={field.value ? String(field.value) : undefined}>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Seleccionar materia" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {subjects.map(s => (
+                                                <SelectItem key={s.id} value={String(s.id)}>{s.name}</SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                )}
+                            />
                             {errors.data?.subjectId && <p className="text-red-500 text-sm">Requerido</p>}
                         </div>
                         <div className="space-y-2">
                             <Label htmlFor="dayOfWeek">Día de la semana</Label>
-                            <Input id="dayOfWeek" {...register("data.dayOfWeek", { required: true })} />
+                            <Controller
+                                name="data.dayOfWeek"
+                                control={control}
+                                rules={{ required: true }}
+                                render={({ field }) => (
+                                    <Select onValueChange={field.onChange} value={field.value}>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Seleccionar día" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {days.map(d => (
+                                                <SelectItem key={d.value} value={d.value}>{d.label}</SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                )}
+                            />
                             {errors.data?.dayOfWeek && <p className="text-red-500 text-sm">Requerido</p>}
                         </div>
                         <div className="space-y-2">
                             <Label htmlFor="startTime">Hora inicio</Label>
-                            <Input id="startTime" {...register("data.startTime", { required: true })} />
+                            <Input id="startTime" type="time" {...register("data.startTime", { required: true })} />
                             {errors.data?.startTime && <p className="text-red-500 text-sm">Requerido</p>}
                         </div>
                         <div className="space-y-2">
                             <Label htmlFor="endTime">Hora fin</Label>
-                            <Input id="endTime" {...register("data.endTime", { required: true })} />
+                            <Input id="endTime" type="time" {...register("data.endTime", { required: true })} />
                             {errors.data?.endTime && <p className="text-red-500 text-sm">Requerido</p>}
                         </div>
                     </div>
@@ -67,3 +177,4 @@ export const ClassScheduleEditPresenter = ({ onSubmit, onCancel, register, error
         </Card>
     );
 };
+

--- a/src/scolar/presentation/ui/ClassSchedule/List/ClassScheduleListContainer.tsx
+++ b/src/scolar/presentation/ui/ClassSchedule/List/ClassScheduleListContainer.tsx
@@ -2,25 +2,49 @@ import { useEffect, useRef, useState, useTransition } from "react";
 import { useInjection } from "inversify-react";
 import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
 import { ClassSchedule } from "@/scolar/domain/entities/classSchedule";
+import { Course } from "@/scolar/domain/entities/course";
+import { Parallel } from "@/scolar/domain/entities/parallel";
+import { Subject } from "@/scolar/domain/entities/subject";
 import { toast } from "@/hooks/use-toast";
 import { ListClassSchedulesUseCase, ListClassSchedulesCommand } from "@/scolar/application/useCases/classSchedules/listClassSchedulesUseCase";
 import { CLASS_SCHEDULE_LIST_USE_CASE } from "@/scolar/domain/symbols/ClassScheduleSymbol";
 import { ClassScheduleListPresenter } from "./ClassScheduleListPresenter";
 import { useNavigate } from "react-router-dom";
+import { COURSE_LIST_USECASE } from "@/scolar/domain/symbols/CourseSymbol";
+import { PARALLEL_LIST_USECASE } from "@/scolar/domain/symbols/ParallelSymbol";
+import { SUBJECT_LIST_USE_CASE } from "@/scolar/domain/symbols/SubjectSymbol";
+import { ListCoursesUseCase, ListCoursesCommand } from "@/scolar/application/useCases/courses/listCoursesUseCase";
+import { ListParallelUseCase, ListParallelUseCaseCommand } from "@/scolar/application/useCases/parallels/listParallelUseCase";
+import { ListSubjectUseCase, ListSubjectCommand } from "@/scolar/application/useCases/subjects/listSubjectsUseCase";
 
 export const ClassScheduleListContainer = () => {
     const listUseCase = useInjection<ListClassSchedulesUseCase>(CLASS_SCHEDULE_LIST_USE_CASE);
+    const listCourses = useInjection<ListCoursesUseCase>(COURSE_LIST_USECASE);
+    const listParallels = useInjection<ListParallelUseCase>(PARALLEL_LIST_USECASE);
+    const listSubjects = useInjection<ListSubjectUseCase>(SUBJECT_LIST_USE_CASE);
     const [isPending, startTransition] = useTransition();
     const [command, setCommand] = useState({ page: 1, perPage: 10, where: '', orderBy: [] as string[] });
     const [result, setResult] = useState<PaginatedResult<ClassSchedule>>({
         data: [],
         meta: { currentPage: 1, lastPage: 1, next: null, perPage: 10, prev: null, total: 0 }
     });
+    const [courses, setCourses] = useState<Course[]>([]);
+    const [parallels, setParallels] = useState<Parallel[]>([]);
+    const [subjects, setSubjects] = useState<Subject[]>([]);
     const debounceRef = useRef<NodeJS.Timeout | null>(null);
 
     useEffect(() => {
         handleLoad();
     }, [command]);
+
+    useEffect(() => {
+        listCourses.execute(new ListCoursesCommand(1, 100, ["id"]))
+            .then(res => res.isRight() && setCourses((res.extract() as PaginatedResult<Course>).data));
+        listParallels.execute(new ListParallelUseCaseCommand(1, 100, ["id"]))
+            .then(res => res.isRight() && setParallels((res.extract() as PaginatedResult<Parallel>).data));
+        listSubjects.execute(new ListSubjectCommand(1, 100, ["id"]))
+            .then(res => res.isRight() && setSubjects((res.extract() as PaginatedResult<Subject>).data));
+    }, [listCourses, listParallels, listSubjects]);
 
     const handleLoad = () => {
         startTransition(() => {
@@ -52,6 +76,9 @@ export const ClassScheduleListContainer = () => {
             onPaginate={handlePaginate}
             isPending={isPending}
             onSearch={handleSearch}
+            courses={courses}
+            parallels={parallels}
+            subjects={subjects}
         />
     );
 };

--- a/src/scolar/presentation/ui/ClassSchedule/List/ClassScheduleListPresenter.tsx
+++ b/src/scolar/presentation/ui/ClassSchedule/List/ClassScheduleListPresenter.tsx
@@ -6,7 +6,11 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Input } from "@/components/ui/input";
 import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
 import { ClassSchedule } from "@/scolar/domain/entities/classSchedule";
+import { Course } from "@/scolar/domain/entities/course";
+import { Parallel } from "@/scolar/domain/entities/parallel";
+import { Subject } from "@/scolar/domain/entities/subject";
 import { Edit, Plus, Search } from "lucide-react";
+import { format, parse } from "date-fns";
 import { DeleteClassScheduleContainer } from "../Delete/DeleteClassScheduleContainer";
 
 interface Props {
@@ -17,9 +21,23 @@ interface Props {
     onPaginate: (page: number) => void;
     isPending?: boolean;
     onSearch: (term: string) => void;
+    courses: Course[];
+    parallels: Parallel[];
+    subjects: Subject[];
 }
 
-export const ClassScheduleListPresenter = ({ schedules, onEdit, onDelete, onAdd, onPaginate, isPending, onSearch }: Props) => {
+const timeFormat = (value: string) => {
+    try {
+        return format(parse(value, 'HH:mm:ss', new Date()), 'HH:mm');
+    } catch {
+        return value;
+    }
+};
+
+export const ClassScheduleListPresenter = ({ schedules, onEdit, onDelete, onAdd, onPaginate, isPending, onSearch, courses, parallels, subjects }: Props) => {
+    const getCourseName = (id: number) => courses.find(c => c.id === id)?.name || '';
+    const getParallelName = (id: number) => parallels.find(p => p.id === id)?.name || '';
+    const getSubjectName = (id: number) => subjects.find(s => s.id === id)?.name || '';
     return (
         <Card>
             <CardHeader className="flex flex-row items-center justify-between">
@@ -38,9 +56,9 @@ export const ClassScheduleListPresenter = ({ schedules, onEdit, onDelete, onAdd,
                         <TableRow>
                             <TableHead>Curso</TableHead>
                             <TableHead>Paralelo</TableHead>
+                            <TableHead>Materia</TableHead>
                             <TableHead>Día</TableHead>
-                            <TableHead>Inicio</TableHead>
-                            <TableHead>Fin</TableHead>
+                            <TableHead>Horario</TableHead>
                             <TableHead className="text-right">Acciones</TableHead>
                         </TableRow>
                     </TableHeader>
@@ -54,11 +72,11 @@ export const ClassScheduleListPresenter = ({ schedules, onEdit, onDelete, onAdd,
                         )}
                         {schedules.data.map((m) => (
                             <TableRow key={m.id}>
-                                <TableCell className="font-medium">{m.courseId}</TableCell>
-                                <TableCell>{m.parallelId}</TableCell>
+                                <TableCell className="font-medium">{getCourseName(m.courseId)}</TableCell>
+                                <TableCell>{getParallelName(m.parallelId)}</TableCell>
+                                <TableCell>{getSubjectName(m.subjectId)}</TableCell>
                                 <TableCell>{m.dayOfWeek}</TableCell>
-                                <TableCell>{m.startTime}</TableCell>
-                                <TableCell>{m.endTime}</TableCell>
+                                <TableCell>{`${timeFormat(m.startTime)} - ${timeFormat(m.endTime)}`}</TableCell>
                                 <TableCell className="text-right">
                                     <div className="flex justify-end gap-2">
                                         <Button variant="ghost" size="icon" onClick={() => onEdit(m)}>


### PR DESCRIPTION
## Summary
- replace ID inputs with dynamic selects for class schedules and academic plannings
- display related names and formatted dates in schedule and planning lists

## Testing
- `npm run lint` *(fails: Fast refresh only works when a file only exports components)*

------
https://chatgpt.com/codex/tasks/task_e_689562f86d5c83308706c4cc3ff2cf98