### PR TITLE
Improve grading term form and list interfaces

### DIFF
--- a/src/scolar/presentation/hooks/useAcademicYears.ts
+++ b/src/scolar/presentation/hooks/useAcademicYears.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+import { useInjection } from "inversify-react";
+import { ListSchoolYearUseCase, ListSchoolYearUseCaseCommand } from "@/scolar/application/useCases/schoolYears/listSchoolYearUseCase";
+import { SCHOOL_YEAR_LIST_USE_CASE } from "@/scolar/domain/symbols/SchoolYearSymbol";
+import { SchoolYear } from "@/scolar/domain/entities/school_year";
+import { toast } from "@/hooks/use-toast";
+
+export const useAcademicYears = () => {
+  const listUseCase = useInjection<ListSchoolYearUseCase>(SCHOOL_YEAR_LIST_USE_CASE);
+  const [years, setYears] = useState<SchoolYear[]>([]);
+
+  useEffect(() => {
+    listUseCase
+      .execute(new ListSchoolYearUseCaseCommand(1, 100, []))
+      .then((res) => {
+        if (res.isLeft()) {
+          toast({
+            title: "Error",
+            description: "No se pudieron cargar los años académicos",
+            variant: "destructive",
+          });
+          return;
+        }
+        const data = res.extract();
+        setYears(data ? data.data : []);
+      });
+  }, [listUseCase]);
+
+  return years;
+};
+

--- a/src/scolar/presentation/hooks/useSystems.ts
+++ b/src/scolar/presentation/hooks/useSystems.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+import { useInjection } from "inversify-react";
+import { ListGradingSystemUseCase, ListGradingSystemCommand } from "@/scolar/application/useCases/gradingSystems/listGradingSystemUseCase";
+import { GRADING_SYSTEM_LIST_USECASE } from "@/scolar/domain/symbols/GradingSystemSymbol";
+import { GradingSystem } from "@/scolar/domain/entities/grading_system";
+import { toast } from "@/hooks/use-toast";
+
+export const useSystems = () => {
+  const listUseCase = useInjection<ListGradingSystemUseCase>(GRADING_SYSTEM_LIST_USECASE);
+  const [systems, setSystems] = useState<GradingSystem[]>([]);
+
+  useEffect(() => {
+    listUseCase
+      .execute(new ListGradingSystemCommand(1, 100, []))
+      .then((res) => {
+        if (res.isLeft()) {
+          toast({
+            title: "Error",
+            description: "No se pudieron cargar los sistemas",
+            variant: "destructive",
+          });
+          return;
+        }
+        const data = res.extract();
+        setSystems(data ? data.data : []);
+      });
+  }, [listUseCase]);
+
+  return systems;
+};
+

--- a/src/scolar/presentation/ui/GradingTerm/Create/GradingTermCreatePresenter.tsx
+++ b/src/scolar/presentation/ui/GradingTerm/Create/GradingTermCreatePresenter.tsx
@@ -1,69 +1,249 @@
+import { format } from "date-fns";
+import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
-import { FieldErrors, UseFormRegister } from "react-hook-form";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Slider } from "@/components/ui/slider";
+import { useSystems } from "@/scolar/presentation/hooks/useSystems";
+import { useAcademicYears } from "@/scolar/presentation/hooks/useAcademicYears";
+import { GradingSystem } from "@/scolar/domain/entities/grading_system";
+import { SchoolYear } from "@/scolar/domain/entities/school_year";
+import { UseFormReturn } from "react-hook-form";
 
 interface FormValues {
-    data: {
-        gradingSystem_id: number;
-        academicYear_id: number;
-        name: string;
-        order: number;
-        weight: string;
-    }
+  data: {
+    gradingSystem_id: number;
+    academicYear_id: number;
+    name: string;
+    order: number;
+    weight: number;
+  };
 }
 
 interface Props {
-    onSubmit: () => void;
-    onCancel: () => void;
-    register: UseFormRegister<FormValues>;
-    errors: FieldErrors<FormValues>;
-    isSubmitting: boolean;
-    formData: FormValues['data'];
+  form: UseFormReturn<FormValues>;
+  onSubmit: (values: FormValues) => void;
+  onCancel: () => void;
+  isSubmitting: boolean;
 }
 
-export const GradingTermCreatePresenter = ({ onSubmit, onCancel, register, errors, isSubmitting }: Props) => {
-    return (
+export const GradingTermCreatePresenter = ({
+  form,
+  onSubmit,
+  onCancel,
+  isSubmitting,
+}: Props) => {
+  const systems = useSystems();
+  const years = useAcademicYears();
+  const selectedSystem = systems.find(
+    (s: GradingSystem) => s.id === form.watch("data.gradingSystem_id")
+  );
+  const selectedYear = years.find(
+    (y: SchoolYear) => y.id === form.watch("data.academicYear_id")
+  );
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
         <Card>
-            <CardHeader>
-                <CardTitle>Nuevo Período de Calificación</CardTitle>
-            </CardHeader>
-            <form onSubmit={onSubmit}>
-                <CardContent className="space-y-4">
-                    <div className="space-y-2">
-                        <Label htmlFor="gradingSystem_id">ID Sistema</Label>
-                        <Input id="gradingSystem_id" type="number" {...register('data.gradingSystem_id', { required: true, valueAsNumber: true })} />
-                        {errors.data?.gradingSystem_id && <span className="text-red-500 text-sm">{errors.data.gradingSystem_id.message}</span>}
+          <CardHeader>
+            <CardTitle>Información del Período de Calificación</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="data.gradingSystem_id"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Sistema de Calificación</FormLabel>
+                    <Select
+                      onValueChange={(value) => field.onChange(Number(value))}
+                      value={field.value ? String(field.value) : ""}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Seleccione un sistema" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {systems.map((s) => (
+                          <SelectItem key={s.id} value={String(s.id)}>
+                            <div className="flex flex-col">
+                              <span>{s.name}</span>
+                              {s.description && (
+                                <span className="text-xs text-muted-foreground">
+                                  {s.description}
+                                </span>
+                              )}
+                            </div>
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormDescription>
+                      Selecciona el sistema al que pertenece el período.
+                    </FormDescription>
+                    <FormMessage />
+                    {selectedSystem && (
+                      <p className="text-sm text-muted-foreground">
+                        Sistema {selectedSystem.name}, {selectedSystem.description}
+                      </p>
+                    )}
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="data.academicYear_id"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Año Académico</FormLabel>
+                    <Select
+                      onValueChange={(value) => field.onChange(Number(value))}
+                      value={field.value ? String(field.value) : ""}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Seleccione un año" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {years.map((y) => (
+                          <SelectItem key={y.id} value={String(y.id)}>
+                            <div className="flex flex-col">
+                              <span>{y.name}</span>
+                              <span className="text-xs text-muted-foreground">
+                                {format(y.startDate, "dd/MM/yyyy")} -
+                                {" "}
+                                {format(y.endDate, "dd/MM/yyyy")}
+                              </span>
+                            </div>
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormDescription>
+                      Selecciona el año académico correspondiente.
+                    </FormDescription>
+                    <FormMessage />
+                    {selectedYear && (
+                      <p className="text-sm text-muted-foreground">
+                        {selectedYear.name} ({
+                          format(selectedYear.startDate, "dd/MM/yyyy")
+                        }
+                        -
+                        {format(selectedYear.endDate, "dd/MM/yyyy")})
+                      </p>
+                    )}
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="data.name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Nombre</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormDescription>
+                      Nombre descriptivo del período de calificación.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="data.order"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Orden</FormLabel>
+                    <FormControl>
+                      <Input type="number" {...field} />
+                    </FormControl>
+                    <FormDescription>
+                      Posición del período dentro del sistema.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="data.weight"
+                render={({ field }) => (
+                  <FormItem className="col-span-2">
+                    <FormLabel>Peso</FormLabel>
+                    <FormControl>
+                      <Slider
+                        min={0}
+                        max={1}
+                        step={0.05}
+                        value={[field.value ?? 0]}
+                        onValueChange={(val) => field.onChange(val[0])}
+                      />
+                    </FormControl>
+                    <div className="text-sm text-muted-foreground mt-2">
+                      Valor: {field.value?.toFixed(2)}
                     </div>
-                    <div className="space-y-2">
-                        <Label htmlFor="academicYear_id">ID Año Académico</Label>
-                        <Input id="academicYear_id" type="number" {...register('data.academicYear_id', { required: true, valueAsNumber: true })} />
-                        {errors.data?.academicYear_id && <span className="text-red-500 text-sm">{errors.data.academicYear_id.message}</span>}
-                    </div>
-                    <div className="space-y-2">
-                        <Label htmlFor="name">Nombre</Label>
-                        <Input id="name" {...register('data.name', { required: true })} />
-                        {errors.data?.name && <span className="text-red-500 text-sm">{errors.data.name.message}</span>}
-                    </div>
-                    <div className="space-y-2">
-                        <Label htmlFor="order">Orden</Label>
-                        <Input id="order" type="number" {...register('data.order', { required: true, valueAsNumber: true })} />
-                        {errors.data?.order && <span className="text-red-500 text-sm">{errors.data.order.message}</span>}
-                    </div>
-                    <div className="space-y-2">
-                        <Label htmlFor="weight">Peso</Label>
-                        <Input id="weight" {...register('data.weight', { required: true })} />
-                        {errors.data?.weight && <span className="text-red-500 text-sm">{errors.data.weight.message}</span>}
-                    </div>
-                </CardContent>
-                <CardFooter className="flex justify-between">
-                    <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>Cancelar</Button>
-                    <Button type="submit" disabled={isSubmitting}>{isSubmitting ? 'Guardando...' : 'Guardar'}</Button>
-                </CardFooter>
-            </form>
+                    <FormDescription>
+                      Define el peso relativo del período (0 a 1).
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+          </CardContent>
+          <CardFooter className="flex justify-between">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onCancel}
+              disabled={isSubmitting}
+            >
+              Cancelar
+            </Button>
+            <Button
+              type="submit"
+              disabled={isSubmitting || !form.formState.isValid}
+            >
+              {isSubmitting ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Guardando...
+                </>
+              ) : (
+                "Guardar"
+              )}
+            </Button>
+          </CardFooter>
         </Card>
-    );
+      </form>
+    </Form>
+  );
 };
 

--- a/src/scolar/presentation/ui/GradingTerm/Delete/GradingTermDeletePresenter.tsx
+++ b/src/scolar/presentation/ui/GradingTerm/Delete/GradingTermDeletePresenter.tsx
@@ -1,5 +1,20 @@
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { GradingTerm } from "@/scolar/domain/entities/grading_term";
 import { Trash } from "lucide-react";
 
@@ -11,11 +26,18 @@ interface Props {
 export const GradingTermDeletePresenter = ({ gradingTerm, onConfirm }: Props) => {
     return (
         <Dialog>
-            <DialogTrigger asChild>
-                <button title="Eliminar" type="button" className="p-1 rounded-full hover:bg-primary-500 transition">
-                    <Trash className="w-5 h-5 text-primary-200 hover:text-white" />
-                </button>
-            </DialogTrigger>
+            <TooltipProvider>
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <DialogTrigger asChild>
+                            <button type="button" className="p-1 rounded-full hover:bg-primary-500 transition">
+                                <Trash className="w-5 h-5 text-primary-200 hover:text-white" />
+                            </button>
+                        </DialogTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent>Eliminar</TooltipContent>
+                </Tooltip>
+            </TooltipProvider>
             <DialogContent className="sm:max-w-md">
                 <DialogHeader>
                     <DialogTitle>¿Eliminar período?</DialogTitle>

--- a/src/scolar/presentation/ui/GradingTerm/Edit/GradingTermEditInlineContainer.tsx
+++ b/src/scolar/presentation/ui/GradingTerm/Edit/GradingTermEditInlineContainer.tsx
@@ -1,0 +1,111 @@
+import { useState, useTransition } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { useInjection } from "inversify-react";
+import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
+import { toast } from "@/hooks/use-toast";
+import { GradingTerm } from "@/scolar/domain/entities/grading_term";
+import {
+  UpdateGradingTermUseCase,
+  UpdateGradingTermCommand,
+} from "@/scolar/application/useCases/gradingTerms/updateGradingTermUseCase";
+import { GRADING_TERM_UPDATE_USECASE } from "@/scolar/domain/symbols/GradingTermSymbol";
+import { GradingTermEditPresenter } from "./GradingTermEditPresenter";
+
+const formSchema = z.object({
+  data: z.object({
+    gradingSystem_id: z
+      .number({ required_error: "Seleccione un sistema" })
+      .positive(),
+    academicYear_id: z
+      .number({ required_error: "Seleccione un año" })
+      .positive(),
+    name: z.string().min(1, "El nombre es obligatorio"),
+    order: z
+      .number({ required_error: "El orden es obligatorio" })
+      .min(1),
+    weight: z
+      .number({ required_error: "El peso es obligatorio" })
+      .min(0)
+      .max(1),
+  }),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+interface Props {
+  gradingTerm: GradingTerm;
+  onUpdated: () => void;
+  children: React.ReactNode;
+}
+
+export const GradingTermEditInlineContainer = ({
+  gradingTerm,
+  onUpdated,
+  children,
+}: Props) => {
+  const [open, setOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const updateGT = useInjection<UpdateGradingTermUseCase>(
+    GRADING_TERM_UPDATE_USECASE
+  );
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      data: {
+        gradingSystem_id: gradingTerm.gradingSystem_id,
+        academicYear_id: gradingTerm.academicYear_id,
+        name: gradingTerm.name,
+        order: gradingTerm.order,
+        weight: parseFloat(gradingTerm.weight),
+      },
+    },
+    mode: "onChange",
+  });
+
+  const onSubmit = (values: FormValues) => {
+    startTransition(async () => {
+      const command = new UpdateGradingTermCommand(
+        gradingTerm.id,
+        values.data.gradingSystem_id,
+        values.data.academicYear_id,
+        values.data.name,
+        values.data.order,
+        values.data.weight.toString()
+      );
+      const res = await updateGT.execute(command);
+      if (res.isLeft()) {
+        const fail = res.extract();
+        toast({
+          title: "Error",
+          description: fail.map((f) => f.getMessage()).join(", "),
+          variant: "destructive",
+        });
+        return;
+      }
+      toast({
+        title: "Período actualizado",
+        description: "Cambios guardados",
+        variant: "success",
+      });
+      onUpdated();
+      setOpen(false);
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="max-w-2xl">
+        <GradingTermEditPresenter
+          form={form}
+          onSubmit={onSubmit}
+          onCancel={() => setOpen(false)}
+          isSubmitting={isPending}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+};
+

--- a/src/scolar/presentation/ui/GradingTerm/Edit/GradingTermEditPresenter.tsx
+++ b/src/scolar/presentation/ui/GradingTerm/Edit/GradingTermEditPresenter.tsx
@@ -1,68 +1,249 @@
+import { format } from "date-fns";
+import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { FieldErrors, UseFormRegister } from "react-hook-form";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Slider } from "@/components/ui/slider";
+import { useSystems } from "@/scolar/presentation/hooks/useSystems";
+import { useAcademicYears } from "@/scolar/presentation/hooks/useAcademicYears";
+import { GradingSystem } from "@/scolar/domain/entities/grading_system";
+import { SchoolYear } from "@/scolar/domain/entities/school_year";
+import { UseFormReturn } from "react-hook-form";
 
 interface FormValues {
-    data: {
-        gradingSystem_id: number;
-        academicYear_id: number;
-        name: string;
-        order: number;
-        weight: string;
-    }
+  data: {
+    gradingSystem_id: number;
+    academicYear_id: number;
+    name: string;
+    order: number;
+    weight: number;
+  };
 }
 
 interface Props {
-    onSubmit: () => void;
-    onCancel: () => void;
-    register: UseFormRegister<FormValues>;
-    errors: FieldErrors<FormValues>;
-    isSubmitting: boolean;
-    formData: FormValues['data'];
+  form: UseFormReturn<FormValues>;
+  onSubmit: (values: FormValues) => void;
+  onCancel: () => void;
+  isSubmitting: boolean;
 }
 
-export const GradingTermEditPresenter = ({ onSubmit, onCancel, register, errors, isSubmitting }: Props) => {
-    return (
+export const GradingTermEditPresenter = ({
+  form,
+  onSubmit,
+  onCancel,
+  isSubmitting,
+}: Props) => {
+  const systems = useSystems();
+  const years = useAcademicYears();
+  const selectedSystem = systems.find(
+    (s: GradingSystem) => s.id === form.watch("data.gradingSystem_id")
+  );
+  const selectedYear = years.find(
+    (y: SchoolYear) => y.id === form.watch("data.academicYear_id")
+  );
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
         <Card>
-            <CardHeader>
-                <CardTitle>Editar Período de Calificación</CardTitle>
-            </CardHeader>
-            <form onSubmit={onSubmit}>
-                <CardContent className="space-y-4">
-                    <div className="space-y-2">
-                        <Label htmlFor="gradingSystem_id">ID Sistema</Label>
-                        <Input id="gradingSystem_id" type="number" {...register('data.gradingSystem_id', { required: true, valueAsNumber: true })} />
-                        {errors.data?.gradingSystem_id && <span className="text-red-500 text-sm">{errors.data.gradingSystem_id.message}</span>}
+          <CardHeader>
+            <CardTitle>Información del Período de Calificación</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="data.gradingSystem_id"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Sistema de Calificación</FormLabel>
+                    <Select
+                      onValueChange={(value) => field.onChange(Number(value))}
+                      value={field.value ? String(field.value) : ""}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Seleccione un sistema" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {systems.map((s) => (
+                          <SelectItem key={s.id} value={String(s.id)}>
+                            <div className="flex flex-col">
+                              <span>{s.name}</span>
+                              {s.description && (
+                                <span className="text-xs text-muted-foreground">
+                                  {s.description}
+                                </span>
+                              )}
+                            </div>
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormDescription>
+                      Selecciona el sistema al que pertenece el período.
+                    </FormDescription>
+                    <FormMessage />
+                    {selectedSystem && (
+                      <p className="text-sm text-muted-foreground">
+                        Sistema {selectedSystem.name}, {selectedSystem.description}
+                      </p>
+                    )}
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="data.academicYear_id"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Año Académico</FormLabel>
+                    <Select
+                      onValueChange={(value) => field.onChange(Number(value))}
+                      value={field.value ? String(field.value) : ""}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Seleccione un año" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {years.map((y) => (
+                          <SelectItem key={y.id} value={String(y.id)}>
+                            <div className="flex flex-col">
+                              <span>{y.name}</span>
+                              <span className="text-xs text-muted-foreground">
+                                {format(y.startDate, "dd/MM/yyyy")} -
+                                {" "}
+                                {format(y.endDate, "dd/MM/yyyy")}
+                              </span>
+                            </div>
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormDescription>
+                      Selecciona el año académico correspondiente.
+                    </FormDescription>
+                    <FormMessage />
+                    {selectedYear && (
+                      <p className="text-sm text-muted-foreground">
+                        {selectedYear.name} ({
+                          format(selectedYear.startDate, "dd/MM/yyyy")
+                        }
+                        -
+                        {format(selectedYear.endDate, "dd/MM/yyyy")})
+                      </p>
+                    )}
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="data.name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Nombre</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormDescription>
+                      Nombre descriptivo del período de calificación.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="data.order"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Orden</FormLabel>
+                    <FormControl>
+                      <Input type="number" {...field} />
+                    </FormControl>
+                    <FormDescription>
+                      Posición del período dentro del sistema.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="data.weight"
+                render={({ field }) => (
+                  <FormItem className="col-span-2">
+                    <FormLabel>Peso</FormLabel>
+                    <FormControl>
+                      <Slider
+                        min={0}
+                        max={1}
+                        step={0.05}
+                        value={[field.value ?? 0]}
+                        onValueChange={(val) => field.onChange(val[0])}
+                      />
+                    </FormControl>
+                    <div className="text-sm text-muted-foreground mt-2">
+                      Valor: {field.value?.toFixed(2)}
                     </div>
-                    <div className="space-y-2">
-                        <Label htmlFor="academicYear_id">ID Año Académico</Label>
-                        <Input id="academicYear_id" type="number" {...register('data.academicYear_id', { required: true, valueAsNumber: true })} />
-                        {errors.data?.academicYear_id && <span className="text-red-500 text-sm">{errors.data.academicYear_id.message}</span>}
-                    </div>
-                    <div className="space-y-2">
-                        <Label htmlFor="name">Nombre</Label>
-                        <Input id="name" {...register('data.name', { required: true })} />
-                        {errors.data?.name && <span className="text-red-500 text-sm">{errors.data.name.message}</span>}
-                    </div>
-                    <div className="space-y-2">
-                        <Label htmlFor="order">Orden</Label>
-                        <Input id="order" type="number" {...register('data.order', { required: true, valueAsNumber: true })} />
-                        {errors.data?.order && <span className="text-red-500 text-sm">{errors.data.order.message}</span>}
-                    </div>
-                    <div className="space-y-2">
-                        <Label htmlFor="weight">Peso</Label>
-                        <Input id="weight" {...register('data.weight', { required: true })} />
-                        {errors.data?.weight && <span className="text-red-500 text-sm">{errors.data.weight.message}</span>}
-                    </div>
-                </CardContent>
-                <CardFooter className="flex justify-between">
-                    <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>Cancelar</Button>
-                    <Button type="submit" disabled={isSubmitting}>{isSubmitting ? 'Guardando...' : 'Guardar'}</Button>
-                </CardFooter>
-            </form>
+                    <FormDescription>
+                      Define el peso relativo del período (0 a 1).
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+          </CardContent>
+          <CardFooter className="flex justify-between">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onCancel}
+              disabled={isSubmitting}
+            >
+              Cancelar
+            </Button>
+            <Button
+              type="submit"
+              disabled={isSubmitting || !form.formState.isValid}
+            >
+              {isSubmitting ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Guardando...
+                </>
+              ) : (
+                "Guardar"
+              )}
+            </Button>
+          </CardFooter>
         </Card>
-    );
+      </form>
+    </Form>
+  );
 };
 

--- a/src/scolar/presentation/ui/GradingTerm/List/GradingTermListContainer.tsx
+++ b/src/scolar/presentation/ui/GradingTerm/List/GradingTermListContainer.tsx
@@ -4,7 +4,10 @@ import { useNavigate } from "react-router-dom";
 import { toast } from "@/hooks/use-toast";
 import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
 import { GradingTerm } from "@/scolar/domain/entities/grading_term";
-import { ListGradingTermUseCase, ListGradingTermCommand } from "@/scolar/application/useCases/gradingTerms/listGradingTermUseCase";
+import {
+    ListGradingTermUseCase,
+    ListGradingTermCommand,
+} from "@/scolar/application/useCases/gradingTerms/listGradingTermUseCase";
 import { GRADING_TERM_LIST_USECASE } from "@/scolar/domain/symbols/GradingTermSymbol";
 import { GradingTermListPresenter } from "./GradingTermListPresenter";
 
@@ -33,20 +36,20 @@ export const GradingTermListContainer = () => {
     useEffect(() => { loadData(); }, [command]);
 
     const handleAdd = () => navigate('/terminos-calificacion/nuevo');
-    const handleEdit = (gt: GradingTerm) => navigate(`/terminos-calificacion/${gt.id}`);
     const handlePaginate = (page: number) => setCommand({ ...command, page });
     const handleSearch = (term: string) => {
         if (debounceRef.current) clearTimeout(debounceRef.current);
         debounceRef.current = setTimeout(() => setCommand({ ...command, where: term }), 300);
     };
     const handleDeleted = () => loadData();
+    const handleUpdated = () => loadData();
 
     return (
         <GradingTermListPresenter
             gradingTerms={result}
             onAdd={handleAdd}
-            onEdit={handleEdit}
             onDeleted={handleDeleted}
+            onUpdated={handleUpdated}
             onPaginate={handlePaginate}
             onSearch={handleSearch}
             isPending={isPending}

--- a/src/scolar/presentation/ui/GradingTerm/List/GradingTermListPresenter.tsx
+++ b/src/scolar/presentation/ui/GradingTerm/List/GradingTermListPresenter.tsx
@@ -1,64 +1,211 @@
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Pagination, PaginationContent, PaginationItem, PaginationLink, PaginationNext, PaginationPrevious } from "@/components/ui/pagination";
+import {
+    Pagination,
+    PaginationContent,
+    PaginationItem,
+    PaginationLink,
+    PaginationNext,
+    PaginationPrevious,
+} from "@/components/ui/pagination";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Input } from "@/components/ui/input";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Badge } from "@/components/ui/badge";
 import { Search, Edit, Plus } from "lucide-react";
 import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
 import { GradingTerm } from "@/scolar/domain/entities/grading_term";
+import { useSystems } from "@/scolar/presentation/hooks/useSystems";
+import { useAcademicYears } from "@/scolar/presentation/hooks/useAcademicYears";
 import { GradingTermDeleteContainer } from "../Delete/GradingTermDeleteContainer";
+import { GradingTermEditInlineContainer } from "../Edit/GradingTermEditInlineContainer";
 
 interface Props {
     gradingTerms: PaginatedResult<GradingTerm>;
     onAdd: () => void;
-    onEdit: (gt: GradingTerm) => void;
     onDeleted: () => void;
+    onUpdated: () => void;
     onPaginate: (page: number) => void;
     onSearch: (term: string) => void;
     isPending?: boolean;
 }
 
-export const GradingTermListPresenter = ({ gradingTerms, onAdd, onEdit, onDeleted, onPaginate, onSearch, isPending }: Props) => {
+export const GradingTermListPresenter = ({
+    gradingTerms,
+    onAdd,
+    onDeleted,
+    onUpdated,
+    onPaginate,
+    onSearch,
+    isPending,
+}: Props) => {
+    const systems = useSystems();
+    const years = useAcademicYears();
+    const [systemFilter, setSystemFilter] = useState<number | undefined>();
+    const [yearFilter, setYearFilter] = useState<number | undefined>();
+    const filteredTerms = gradingTerms.data.filter(
+        (gt) =>
+            (!systemFilter || gt.gradingSystem_id === systemFilter) &&
+            (!yearFilter || gt.academicYear_id === yearFilter)
+    );
     return (
         <Card>
             <CardHeader className="flex flex-row items-center justify-between">
                 <CardTitle>Períodos de Calificación</CardTitle>
-                <Button onClick={onAdd} size="sm"><Plus className="h-4 w-4 mr-2" /> Nuevo</Button>
+                <Button onClick={onAdd} size="sm">
+                    <Plus className="h-4 w-4 mr-2" /> Nuevo
+                </Button>
             </CardHeader>
             <CardContent>
-                <div className="relative flex-1 mb-4">
-                    <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-                    <Input type="search" placeholder="Buscar..." className="pl-9" onChange={e => onSearch(e.target.value)} />
+                <div className="flex gap-4 mb-4 flex-wrap">
+                    <div className="relative flex-1 min-w-[200px]">
+                        <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+                        <Input
+                            type="search"
+                            placeholder="Buscar..."
+                            className="pl-9"
+                            onChange={(e) => onSearch(e.target.value)}
+                        />
+                    </div>
+                    <Select
+                        value={systemFilter ? String(systemFilter) : ""}
+                        onValueChange={(val) =>
+                            setSystemFilter(val ? Number(val) : undefined)
+                        }
+                    >
+                        <SelectTrigger className="w-[180px]">
+                            <SelectValue placeholder="Sistema" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="">Todos</SelectItem>
+                            {systems.map((s) => (
+                                <SelectItem key={s.id} value={String(s.id)}>
+                                    {s.name}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                    <Select
+                        value={yearFilter ? String(yearFilter) : ""}
+                        onValueChange={(val) =>
+                            setYearFilter(val ? Number(val) : undefined)
+                        }
+                    >
+                        <SelectTrigger className="w-[180px]">
+                            <SelectValue placeholder="Año" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="">Todos</SelectItem>
+                            {years.map((y) => (
+                                <SelectItem key={y.id} value={String(y.id)}>
+                                    {y.name}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
                 </div>
                 <Table>
                     <TableHeader>
                         <TableRow>
+                            <TableHead>Año Académico</TableHead>
+                            <TableHead>Sistema</TableHead>
                             <TableHead>Nombre</TableHead>
-                            <TableHead>Orden</TableHead>
+                            <TableHead className="w-20">Orden</TableHead>
                             <TableHead>Peso</TableHead>
                             <TableHead className="text-right">Acciones</TableHead>
                         </TableRow>
                     </TableHeader>
                     <TableBody>
                         {isPending && (
-                            <TableRow><TableCell colSpan={4}><Skeleton className="h-4 w-full" /></TableCell></TableRow>
-                        )}
-                        {gradingTerms.data.map(gt => (
-                            <TableRow key={gt.id}>
-                                <TableCell className="font-medium">{gt.name}</TableCell>
-                                <TableCell>{gt.order}</TableCell>
-                                <TableCell>{gt.weight}</TableCell>
-                                <TableCell className="text-right">
-                                    <div className="flex justify-end gap-2">
-                                        <Button variant="ghost" size="icon" onClick={() => onEdit(gt)}>
-                                            <Edit className="h-4 w-4" />
-                                        </Button>
-                                        <GradingTermDeleteContainer gradingTerm={gt} onConfirm={onDeleted} />
-                                    </div>
+                            <TableRow>
+                                <TableCell colSpan={6}>
+                                    <Skeleton className="h-4 w-full" />
                                 </TableCell>
                             </TableRow>
-                        ))}
+                        )}
+                        {!isPending && filteredTerms.length === 0 && (
+                            <TableRow>
+                                <TableCell colSpan={6} className="text-center">
+                                    No se encontraron períodos
+                                </TableCell>
+                            </TableRow>
+                        )}
+                        {filteredTerms.map((gt) => {
+                            const year = years.find((y) => y.id === gt.academicYear_id);
+                            const system = systems.find(
+                                (s) => s.id === gt.gradingSystem_id
+                            );
+                            const weightNum = parseFloat(gt.weight);
+                            const weightValid = weightNum >= 0 && weightNum <= 1;
+                            return (
+                                <TableRow
+                                    key={gt.id}
+                                    className="hover:bg-muted odd:bg-muted/50"
+                                >
+                                    <TableCell>{year?.name}</TableCell>
+                                    <TableCell>
+                                        {system
+                                            ? `${system.name}, escala ${system.passingScore}`
+                                            : ""}
+                                    </TableCell>
+                                    <TableCell className="font-medium">
+                                        {gt.name}
+                                    </TableCell>
+                                    <TableCell>{gt.order}</TableCell>
+                                    <TableCell>
+                                        {weightValid ? (
+                                            `${(weightNum * 100).toFixed(0)}%`
+                                        ) : (
+                                            <Badge variant="destructive">
+                                                Peso inválido
+                                            </Badge>
+                                        )}
+                                    </TableCell>
+                                    <TableCell className="text-right">
+                                        <div className="flex justify-end gap-2">
+                                            <GradingTermEditInlineContainer
+                                                gradingTerm={gt}
+                                                onUpdated={onUpdated}
+                                            >
+                                                <TooltipProvider>
+                                                    <Tooltip>
+                                                        <TooltipTrigger asChild>
+                                                            <Button
+                                                                variant="ghost"
+                                                                size="icon"
+                                                            >
+                                                                <Edit className="h-4 w-4" />
+                                                            </Button>
+                                                        </TooltipTrigger>
+                                                        <TooltipContent>
+                                                            Editar
+                                                        </TooltipContent>
+                                                    </Tooltip>
+                                                </TooltipProvider>
+                                            </GradingTermEditInlineContainer>
+                                            <GradingTermDeleteContainer
+                                                gradingTerm={gt}
+                                                onConfirm={onDeleted}
+                                            />
+                                        </div>
+                                    </TableCell>
+                                </TableRow>
+                            );
+                        })}
                     </TableBody>
                 </Table>
                 <div className="mt-4 flex justify-end items-center gap-4">


### PR DESCRIPTION
## Summary
- enhance grading term list with filters, inline editing, and clearer columns
- show invalid weight indicators and tooltip-driven actions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68956e57ac2c83308b582787085f4a11