### PR TITLE
feat: improve class schedule calendar

### DIFF
--- a/src/scolar/presentation/ui/ClassSchedule/Calendar/ClassScheduleCalendarContainer.tsx
+++ b/src/scolar/presentation/ui/ClassSchedule/Calendar/ClassScheduleCalendarContainer.tsx
@@ -1,39 +1,77 @@
 import { useEffect, useState, useTransition } from "react";
 import { useInjection } from "inversify-react";
-import { useForm } from "react-hook-form";
+import { Controller, useForm } from "react-hook-form";
 import { toast } from "@/hooks/use-toast";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { ClassSchedule } from "@/scolar/domain/entities/classSchedule";
+import { Course } from "@/scolar/domain/entities/course";
+import { Parallel } from "@/scolar/domain/entities/parallel";
+import { Subject } from "@/scolar/domain/entities/subject";
+import { SchoolYear } from "@/scolar/domain/entities/school_year";
 import { ListClassSchedulesUseCase, ListClassSchedulesCommand } from "@/scolar/application/useCases/classSchedules/listClassSchedulesUseCase";
 import { CreateClassScheduleUseCase, CreateClassScheduleCommand } from "@/scolar/application/useCases/classSchedules/createClassScheduleUseCase";
 import { UpdateClassScheduleUseCase, UpdateClassScheduleCommand } from "@/scolar/application/useCases/classSchedules/updateClassScheduleUseCase";
 import { DeleteClassScheduleUseCase, DeleteClassScheduleCommand } from "@/scolar/application/useCases/classSchedules/deleteClassScheduleUseCase";
+import { ListCoursesUseCase, ListCoursesCommand } from "@/scolar/application/useCases/courses/listCoursesUseCase";
+import { ListParallelUseCase, ListParallelUseCaseCommand } from "@/scolar/application/useCases/parallels/listParallelUseCase";
+import { ListSubjectUseCase, ListSubjectCommand } from "@/scolar/application/useCases/subjects/listSubjectsUseCase";
+import { ListSchoolYearUseCase, ListSchoolYearUseCaseCommand } from "@/scolar/application/useCases/schoolYears/listSchoolYearUseCase";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
 import { CLASS_SCHEDULE_LIST_USE_CASE, CLASS_SCHEDULE_CREATE_USE_CASE, CLASS_SCHEDULE_UPDATE_USE_CASE, CLASS_SCHEDULE_DELETE_USE_CASE } from "@/scolar/domain/symbols/ClassScheduleSymbol";
+import { COURSE_LIST_USECASE } from "@/scolar/domain/symbols/CourseSymbol";
+import { PARALLEL_LIST_USECASE } from "@/scolar/domain/symbols/ParallelSymbol";
+import { SUBJECT_LIST_USE_CASE } from "@/scolar/domain/symbols/SubjectSymbol";
+import { SCHOOL_YEAR_LIST_USE_CASE } from "@/scolar/domain/symbols/SchoolYearSymbol";
 import { ClassScheduleCalendarPresenter } from "./ClassScheduleCalendarPresenter";
 
 export const ClassScheduleCalendarContainer = () => {
+    interface ScheduleView extends ClassSchedule {
+        courseName: string;
+        parallelName: string;
+        subjectName: string;
+    }
+
     const listUseCase = useInjection<ListClassSchedulesUseCase>(CLASS_SCHEDULE_LIST_USE_CASE);
     const createUseCase = useInjection<CreateClassScheduleUseCase>(CLASS_SCHEDULE_CREATE_USE_CASE);
     const updateUseCase = useInjection<UpdateClassScheduleUseCase>(CLASS_SCHEDULE_UPDATE_USE_CASE);
     const deleteUseCase = useInjection<DeleteClassScheduleUseCase>(CLASS_SCHEDULE_DELETE_USE_CASE);
+    const listCourses = useInjection<ListCoursesUseCase>(COURSE_LIST_USECASE);
+    const listParallels = useInjection<ListParallelUseCase>(PARALLEL_LIST_USECASE);
+    const listSubjects = useInjection<ListSubjectUseCase>(SUBJECT_LIST_USE_CASE);
+    const listSchoolYears = useInjection<ListSchoolYearUseCase>(SCHOOL_YEAR_LIST_USE_CASE);
 
-    const [schedules, setSchedules] = useState<ClassSchedule[]>([]);
+    const [schedules, setSchedules] = useState<ScheduleView[]>([]);
+    const [courses, setCourses] = useState<Course[]>([]);
+    const [parallels, setParallels] = useState<Parallel[]>([]);
+    const [subjects, setSubjects] = useState<Subject[]>([]);
+    const [schoolYears, setSchoolYears] = useState<SchoolYear[]>([]);
     const [open, setOpen] = useState(false);
-    const [editing, setEditing] = useState<ClassSchedule | null>(null);
+    const [editing, setEditing] = useState<ScheduleView | null>(null);
     const [isPending, startTransition] = useTransition();
 
-    const { register, handleSubmit, reset } = useForm<ClassSchedule>({
+    const { register, handleSubmit, reset, control, watch, formState: { errors }, setError, clearErrors } = useForm<ClassSchedule>({
         defaultValues: { id: 0, courseId: 0, parallelId: 0, schoolYearId: 0, subjectId: 0, dayOfWeek: "", startTime: "", endTime: "" }
     });
+
+    const selectedCourse = watch("courseId");
+    const filteredParallels = parallels.filter(p => p.courseId === Number(selectedCourse));
 
     const load = () => {
         startTransition(() => {
             listUseCase.execute(new ListClassSchedulesCommand(1, 100, [], "")).then(res => {
                 if (res.isRight()) {
-                    setSchedules(res.extract()!.data);
+                    const data = res.extract()!.data;
+                    const mapped: ScheduleView[] = data.map(s => ({
+                        ...s,
+                        courseName: courses.find(c => c.id === s.courseId)?.name || "",
+                        parallelName: parallels.find(p => p.id === s.parallelId)?.name || "",
+                        subjectName: subjects.find(sb => sb.id === s.subjectId)?.name || ""
+                    }));
+                    setSchedules(mapped);
                 } else {
                     toast({ title: "Error", description: "No se pudo cargar", variant: "destructive" });
                 }
@@ -42,22 +80,53 @@ export const ClassScheduleCalendarContainer = () => {
     };
 
     useEffect(() => {
-        load();
+        startTransition(() => {
+            Promise.all([
+                listCourses.execute(new ListCoursesCommand(1, 100, ["id"])),
+                listParallels.execute(new ListParallelUseCaseCommand(1, 100, ["id"])),
+                listSubjects.execute(new ListSubjectCommand(1, 100, ["id"])),
+                listSchoolYears.execute(new ListSchoolYearUseCaseCommand(1, 100, ["id"]))
+            ]).then(([c, p, s, sy]) => {
+                if (c.isRight()) setCourses((c.extract() as PaginatedResult<Course>).data);
+                if (p.isRight()) setParallels((p.extract() as PaginatedResult<Parallel>).data);
+                if (s.isRight()) setSubjects((s.extract() as PaginatedResult<Subject>).data);
+                if (sy.isRight()) setSchoolYears((sy.extract() as PaginatedResult<SchoolYear>).data);
+                load();
+            });
+        });
     }, []);
 
     const handleAdd = (day?: string) => {
         setEditing(null);
         reset({ id: 0, courseId: 0, parallelId: 0, schoolYearId: 0, subjectId: 0, dayOfWeek: day || "", startTime: "", endTime: "" });
+        clearErrors();
         setOpen(true);
     };
 
-    const handleSelect = (s: ClassSchedule) => {
+    const handleSelect = (s: ScheduleView) => {
         setEditing(s);
         reset(s);
+        clearErrors();
         setOpen(true);
     };
 
     const onSubmit = handleSubmit((data) => {
+        if (data.endTime <= data.startTime) {
+            setError("endTime", { type: "manual", message: "La hora de fin debe ser posterior" });
+            return;
+        }
+        const overlapping = schedules.some(s =>
+            s.id !== data.id &&
+            s.courseId === data.courseId &&
+            s.dayOfWeek === data.dayOfWeek &&
+            !(data.endTime <= s.startTime || data.startTime >= s.endTime)
+        );
+        if (overlapping) {
+            setError("startTime", { type: "manual", message: "Se solapa con otro horario" });
+            setError("endTime", { type: "manual", message: "Se solapa con otro horario" });
+            return;
+        }
+        clearErrors(["startTime", "endTime"]);
         startTransition(async () => {
             if (editing) {
                 const res = await updateUseCase.execute(new UpdateClassScheduleCommand(data));
@@ -93,9 +162,22 @@ export const ClassScheduleCalendarContainer = () => {
         });
     };
 
+    const handleBlockDelete = (s: ScheduleView) => {
+        if (!confirm("¿Eliminar esta clase?")) return;
+        startTransition(async () => {
+            const res = await deleteUseCase.execute(new DeleteClassScheduleCommand(s.id));
+            if (res.isLeft()) {
+                toast({ title: "Error", description: "No se pudo eliminar", variant: "destructive" });
+                return;
+            }
+            toast({ title: "Horario eliminado", description: "Eliminado correctamente", variant: "success" });
+            load();
+        });
+    };
+
     return (
         <>
-            <ClassScheduleCalendarPresenter schedules={schedules} onAdd={handleAdd} onSelect={handleSelect} />
+            <ClassScheduleCalendarPresenter schedules={schedules} onAdd={handleAdd} onSelect={handleSelect} onDelete={handleBlockDelete} />
             <Dialog open={open} onOpenChange={setOpen}>
                 <DialogContent>
                     <form onSubmit={onSubmit} className="space-y-4">
@@ -104,32 +186,119 @@ export const ClassScheduleCalendarContainer = () => {
                         </DialogHeader>
                         <div className="grid grid-cols-2 gap-4">
                             <div className="space-y-2">
-                                <Label htmlFor="courseId">Curso ID</Label>
-                                <Input id="courseId" type="number" {...register("courseId", { valueAsNumber: true, required: true })} />
+                                <Label htmlFor="courseId">Curso</Label>
+                                <Controller
+                                    name="courseId"
+                                    control={control}
+                                    rules={{ required: true, valueAsNumber: true }}
+                                    render={({ field }) => (
+                                        <Select onValueChange={(v) => field.onChange(Number(v))} value={field.value ? String(field.value) : undefined}>
+                                            <SelectTrigger id="courseId">
+                                                <SelectValue placeholder="Seleccionar curso" />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                {courses.map(c => (
+                                                    <SelectItem key={c.id} value={String(c.id)}>{c.name}</SelectItem>
+                                                ))}
+                                            </SelectContent>
+                                        </Select>
+                                    )}
+                                />
+                                {errors.courseId && <p className="text-red-500 text-sm">Requerido</p>}
                             </div>
                             <div className="space-y-2">
-                                <Label htmlFor="parallelId">Paralelo ID</Label>
-                                <Input id="parallelId" type="number" {...register("parallelId", { valueAsNumber: true, required: true })} />
+                                <Label htmlFor="parallelId">Paralelo</Label>
+                                <Controller
+                                    name="parallelId"
+                                    control={control}
+                                    rules={{ required: true, valueAsNumber: true }}
+                                    render={({ field }) => (
+                                        <Select onValueChange={(v) => field.onChange(Number(v))} value={field.value ? String(field.value) : undefined}>
+                                            <SelectTrigger id="parallelId">
+                                                <SelectValue placeholder="Seleccionar paralelo" />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                {filteredParallels.map(p => (
+                                                    <SelectItem key={p.id} value={String(p.id)}>{p.name}</SelectItem>
+                                                ))}
+                                            </SelectContent>
+                                        </Select>
+                                    )}
+                                />
+                                {errors.parallelId && <p className="text-red-500 text-sm">Requerido</p>}
                             </div>
                             <div className="space-y-2">
-                                <Label htmlFor="schoolYearId">Periodo Lectivo ID</Label>
-                                <Input id="schoolYearId" type="number" {...register("schoolYearId", { valueAsNumber: true, required: true })} />
+                                <Label htmlFor="subjectId">Materia</Label>
+                                <Controller
+                                    name="subjectId"
+                                    control={control}
+                                    rules={{ required: true, valueAsNumber: true }}
+                                    render={({ field }) => (
+                                        <Select onValueChange={(v) => field.onChange(Number(v))} value={field.value ? String(field.value) : undefined}>
+                                            <SelectTrigger id="subjectId">
+                                                <SelectValue placeholder="Seleccionar materia" />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                {subjects.map(s => (
+                                                    <SelectItem key={s.id} value={String(s.id)}>{s.name}</SelectItem>
+                                                ))}
+                                            </SelectContent>
+                                        </Select>
+                                    )}
+                                />
+                                {errors.subjectId && <p className="text-red-500 text-sm">Requerido</p>}
                             </div>
                             <div className="space-y-2">
-                                <Label htmlFor="subjectId">Materia ID</Label>
-                                <Input id="subjectId" type="number" {...register("subjectId", { valueAsNumber: true, required: true })} />
+                                <Label htmlFor="schoolYearId">Periodo Lectivo</Label>
+                                <Controller
+                                    name="schoolYearId"
+                                    control={control}
+                                    rules={{ required: true, valueAsNumber: true }}
+                                    render={({ field }) => (
+                                        <Select onValueChange={(v) => field.onChange(Number(v))} value={field.value ? String(field.value) : undefined}>
+                                            <SelectTrigger id="schoolYearId">
+                                                <SelectValue placeholder="Seleccionar periodo" />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                {schoolYears.map(sy => (
+                                                    <SelectItem key={sy.id} value={String(sy.id)}>{sy.name}</SelectItem>
+                                                ))}
+                                            </SelectContent>
+                                        </Select>
+                                    )}
+                                />
+                                {errors.schoolYearId && <p className="text-red-500 text-sm">Requerido</p>}
                             </div>
                             <div className="space-y-2">
                                 <Label htmlFor="dayOfWeek">Día</Label>
-                                <Input id="dayOfWeek" {...register("dayOfWeek", { required: true })} />
+                                <Controller
+                                    name="dayOfWeek"
+                                    control={control}
+                                    rules={{ required: true }}
+                                    render={({ field }) => (
+                                        <Select onValueChange={field.onChange} value={field.value}>
+                                            <SelectTrigger id="dayOfWeek">
+                                                <SelectValue placeholder="Seleccionar día" />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                {["Lunes","Martes","Miércoles","Jueves","Viernes","Sábado"].map(d => (
+                                                    <SelectItem key={d} value={d}>{d}</SelectItem>
+                                                ))}
+                                            </SelectContent>
+                                        </Select>
+                                    )}
+                                />
+                                {errors.dayOfWeek && <p className="text-red-500 text-sm">Requerido</p>}
                             </div>
                             <div className="space-y-2">
                                 <Label htmlFor="startTime">Inicio</Label>
-                                <Input id="startTime" {...register("startTime", { required: true })} />
+                                <Input id="startTime" type="time" {...register("startTime", { required: true })} />
+                                {errors.startTime && <p className="text-red-500 text-sm">{errors.startTime.message || 'Requerido'}</p>}
                             </div>
                             <div className="space-y-2">
                                 <Label htmlFor="endTime">Fin</Label>
-                                <Input id="endTime" {...register("endTime", { required: true })} />
+                                <Input id="endTime" type="time" {...register("endTime", { required: true })} />
+                                {errors.endTime && <p className="text-red-500 text-sm">{errors.endTime.message || 'Requerido'}</p>}
                             </div>
                         </div>
                         <DialogFooter className="flex justify-between">

--- a/src/scolar/presentation/ui/ClassSchedule/Calendar/ClassScheduleCalendarPresenter.tsx
+++ b/src/scolar/presentation/ui/ClassSchedule/Calendar/ClassScheduleCalendarPresenter.tsx
@@ -1,23 +1,44 @@
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { ClassSchedule } from "@/scolar/domain/entities/classSchedule";
+import { Trash2 } from "lucide-react";
 
-interface Props {
-    schedules: ClassSchedule[];
-    onAdd: (day?: string) => void;
-    onSelect: (s: ClassSchedule) => void;
+interface ScheduleView extends ClassSchedule {
+    courseName: string;
+    parallelName: string;
+    subjectName: string;
 }
 
-export const ClassScheduleCalendarPresenter = ({ schedules, onAdd, onSelect }: Props) => {
+interface Props {
+    schedules: ScheduleView[];
+    onAdd: (day?: string) => void;
+    onSelect: (s: ScheduleView) => void;
+    onDelete: (s: ScheduleView) => void;
+}
+
+export const ClassScheduleCalendarPresenter = ({ schedules, onAdd, onSelect, onDelete }: Props) => {
     const days = ["Lunes", "Martes", "Miércoles", "Jueves", "Viernes", "Sábado"];
     const startHour = 7;
     const endHour = 20;
     const totalMinutes = (endHour - startHour) * 60;
     const containerHeight = 600; // px
+    const colors = [
+        "bg-blue-500",
+        "bg-green-500",
+        "bg-red-500",
+        "bg-purple-500",
+        "bg-yellow-500",
+        "bg-pink-500",
+        "bg-teal-500",
+        "bg-indigo-500"
+    ];
 
     const timeToMinutes = (time: string) => {
         const [h, m] = time.split(":").map(Number);
         return h * 60 + m;
     };
+
+    const getColor = (id: number) => colors[id % colors.length];
 
     return (
         <div className="space-y-4">
@@ -25,32 +46,50 @@ export const ClassScheduleCalendarPresenter = ({ schedules, onAdd, onSelect }: P
                 <h1 className="text-xl font-bold">Horarios de Clase</h1>
                 <Button onClick={() => onAdd()}>Agregar Clase</Button>
             </div>
-            <div className="grid grid-cols-6 gap-2">
-                {days.map(day => (
-                    <div
-                        key={day}
-                        className="border rounded-md h-[600px] relative"
-                        onClick={() => onAdd(day)}
-                    >
-                        <div className="text-center font-medium border-b">{day}</div>
-                        {schedules.filter(s => s.dayOfWeek === day).map(s => {
-                            const top = ((timeToMinutes(s.startTime) - startHour * 60) / totalMinutes) * containerHeight;
-                            const height = ((timeToMinutes(s.endTime) - timeToMinutes(s.startTime)) / totalMinutes) * containerHeight;
-                            return (
-                                <div
-                                    key={s.id}
-                                    data-type="block"
-                                    onClick={(e) => { e.stopPropagation(); onSelect(s); }}
-                                    className="absolute left-1 right-1 bg-blue-500 text-white rounded p-1 text-xs overflow-hidden cursor-pointer"
-                                    style={{ top: `${top}px`, height: `${height}px` }}
-                                >
-                                    <div>{s.startTime} - {s.endTime}</div>
-                                </div>
-                            );
-                        })}
-                    </div>
-                ))}
-            </div>
+            <TooltipProvider>
+                <div className="grid grid-cols-6 gap-2">
+                    {days.map(day => (
+                        <div
+                            key={day}
+                            className="border rounded-md h-[600px] relative"
+                            onClick={() => onAdd(day)}
+                        >
+                            <div className="text-center font-medium border-b">{day}</div>
+                            {schedules.filter(s => s.dayOfWeek === day).map(s => {
+                                const top = ((timeToMinutes(s.startTime) - startHour * 60) / totalMinutes) * containerHeight;
+                                const height = ((timeToMinutes(s.endTime) - timeToMinutes(s.startTime)) / totalMinutes) * containerHeight;
+                                return (
+                                    <Tooltip key={s.id}>
+                                        <TooltipTrigger asChild>
+                                            <div
+                                                data-type="block"
+                                                onClick={(e) => { e.stopPropagation(); onSelect(s); }}
+                                                className={`absolute left-1 right-1 text-white rounded p-1 text-xs overflow-hidden cursor-pointer ${getColor(s.subjectId)}`}
+                                                style={{ top: `${top}px`, height: `${height}px` }}
+                                            >
+                                                <div className="font-semibold">{s.startTime} - {s.endTime}</div>
+                                                <div>{s.subjectName}</div>
+                                                <div className="text-[10px]">{s.courseName} {s.parallelName}</div>
+                                                <button
+                                                    className="absolute top-1 right-1 opacity-80 hover:opacity-100"
+                                                    onClick={(e) => { e.stopPropagation(); onDelete(s); }}
+                                                >
+                                                    <Trash2 className="h-3 w-3" />
+                                                </button>
+                                            </div>
+                                        </TooltipTrigger>
+                                        <TooltipContent>
+                                            <p className="font-semibold">{s.subjectName}</p>
+                                            <p>{s.courseName} {s.parallelName}</p>
+                                            <p>{s.dayOfWeek}: {s.startTime} - {s.endTime}</p>
+                                        </TooltipContent>
+                                    </Tooltip>
+                                );
+                            })}
+                        </div>
+                    ))}
+                </div>
+            </TooltipProvider>
         </div>
     );
 };


### PR DESCRIPTION
## Summary
- enhance weekly class schedule view with subject and course details, color coding, tooltips and inline deletion
- replace ID inputs with filtered selects and time validation in create/edit modal

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 31 problems including external errors)
- `npm run build` (fails: TypeScript errors in other modules)


------
https://chatgpt.com/codex/tasks/task_e_689576e892d48330ae83e1e43d172a92