### PR TITLE
Enhance grading forms with unified design and searchable selects

### DIFF
--- a/src/components/ui/search-select.tsx
+++ b/src/components/ui/search-select.tsx
@@ -1,0 +1,90 @@
+import * as React from "react";
+import { Button } from "@/components/ui/button";
+import { Check, ChevronsUpDown } from "lucide-react";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+} from "@/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+export interface SearchSelectOption {
+  value: string | number;
+  label: string;
+  subLabel?: string;
+}
+
+interface SearchSelectProps {
+  options: SearchSelectOption[];
+  value?: string | number;
+  onChange: (value: string | number) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyMessage?: string;
+}
+
+export function SearchSelect({
+  options,
+  value,
+  onChange,
+  placeholder = "Seleccionar...",
+  searchPlaceholder = "Buscar...",
+  emptyMessage = "Sin resultados.",
+}: SearchSelectProps) {
+  const [open, setOpen] = React.useState(false);
+  const selected = options.find((o) => String(o.value) === String(value));
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className="w-full justify-between"
+        >
+          {selected ? selected.label : placeholder}
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-full p-0">
+        <Command>
+          <CommandInput placeholder={searchPlaceholder} />
+          <CommandEmpty>{emptyMessage}</CommandEmpty>
+          <CommandGroup>
+            {options.map((option) => (
+              <CommandItem
+                key={option.value}
+                value={String(option.value)}
+                onSelect={() => {
+                  onChange(option.value);
+                  setOpen(false);
+                }}
+              >
+                <div className="flex flex-col">
+                  <span>{option.label}</span>
+                  {option.subLabel && (
+                    <span className="text-xs text-muted-foreground">
+                      {option.subLabel}
+                    </span>
+                  )}
+                </div>
+                <Check
+                  className={cn(
+                    "ml-auto h-4 w-4",
+                    String(value) === String(option.value)
+                      ? "opacity-100"
+                      : "opacity-0"
+                  )}
+                />
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/scolar/presentation/ui/EvaluationType/Create/EvaluationTypeCreateContainer.tsx
+++ b/src/scolar/presentation/ui/EvaluationType/Create/EvaluationTypeCreateContainer.tsx
@@ -4,14 +4,17 @@ import { useForm } from "react-hook-form";
 import { useTransition } from "react";
 import { toast } from "@/hooks/use-toast";
 import { EvaluationTypeCreatePresenter } from "./EvaluationTypeCreatePresenter";
-import { CreateEvaluationTypeUseCase, CreateEvaluationTypeCommand } from "@/scolar/application/useCases/evaluationTypes/createEvaluationTypeUseCase";
+import {
+  CreateEvaluationTypeUseCase,
+  CreateEvaluationTypeCommand,
+} from "@/scolar/application/useCases/evaluationTypes/createEvaluationTypeUseCase";
 import { EVALUATION_TYPE_CREATE_USECASE } from "@/scolar/domain/symbols/EvaluationTypeSymbol";
 
 interface FormValues {
     data: {
         name: string;
         description: string;
-        weight: string;
+        weight: number;
     }
 }
 
@@ -19,17 +22,19 @@ export const EvaluationTypeCreateContainer = () => {
     const navigate = useNavigate();
     const [isPending, startTransition] = useTransition();
     const createEvalType = useInjection<CreateEvaluationTypeUseCase>(EVALUATION_TYPE_CREATE_USECASE);
-    const { register, handleSubmit, formState: { errors }, watch } = useForm<FormValues>({
+    const form = useForm<FormValues>({
         defaultValues: {
-            data: { name: "", description: "", weight: "" }
+            data: { name: "", description: "", weight: 0 }
         }
     });
 
-    const formData = watch("data");
-
     const onSubmit = (values: FormValues) => {
         startTransition(async () => {
-            const command = new CreateEvaluationTypeCommand(values.data.name, values.data.description, values.data.weight);
+            const command = new CreateEvaluationTypeCommand(
+                values.data.name,
+                values.data.description,
+                values.data.weight.toString()
+            );
             const res = await createEvalType.execute(command);
             if (res.isLeft()) {
                 const fail = res.extract();
@@ -53,12 +58,10 @@ export const EvaluationTypeCreateContainer = () => {
 
     return (
         <EvaluationTypeCreatePresenter
-            onSubmit={handleSubmit(onSubmit)}
-            register={register}
-            errors={errors}
+            form={form}
+            onSubmit={onSubmit}
             isSubmitting={isPending}
             onCancel={onCancel}
-            formData={formData}
         />
     );
 };

--- a/src/scolar/presentation/ui/EvaluationType/Create/EvaluationTypeCreatePresenter.tsx
+++ b/src/scolar/presentation/ui/EvaluationType/Create/EvaluationTypeCreatePresenter.tsx
@@ -1,61 +1,114 @@
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { FieldErrors, UseFormRegister } from "react-hook-form";
+import { Slider } from "@/components/ui/slider";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { UseFormReturn } from "react-hook-form";
 
 interface FormValues {
     data: {
         name: string;
         description: string;
-        weight: string;
+        weight: number;
     }
 }
 
 interface Props {
-    onSubmit: () => void;
-    onCancel: () => void;
-    register: UseFormRegister<FormValues>;
-    errors: FieldErrors<FormValues>;
-    isSubmitting: boolean;
-    formData: FormValues['data'];
+  form: UseFormReturn<FormValues>;
+  onSubmit: (values: FormValues) => void;
+  onCancel: () => void;
+  isSubmitting: boolean;
 }
 
-export const EvaluationTypeCreatePresenter = ({ onSubmit, onCancel, register, errors, isSubmitting }: Props) => {
-    return (
+export const EvaluationTypeCreatePresenter = ({ form, onSubmit, onCancel, isSubmitting }: Props) => {
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
         <Card>
-            <CardHeader>
-                <CardTitle>Nuevo Tipo de Evaluación</CardTitle>
-            </CardHeader>
-            <form onSubmit={onSubmit}>
-                <CardContent className="space-y-4">
-                    <div className="space-y-2">
-                        <Label htmlFor="name">Nombre</Label>
-                        <Input id="name" {...register('data.name', { required: true })} />
-                        {errors.data?.name && (<span className="text-red-500 text-sm">{errors.data.name.message}</span>)}
-                    </div>
-                    <div className="space-y-2">
-                        <Label htmlFor="description">Descripción</Label>
-                        <Textarea id="description" {...register('data.description', { required: true })} />
-                        {errors.data?.description && (<span className="text-red-500 text-sm">{errors.data.description.message}</span>)}
-                    </div>
-                    <div className="space-y-2">
-                        <Label htmlFor="weight">Peso</Label>
-                        <Input id="weight" {...register('data.weight', { required: true })} />
-                        {errors.data?.weight && (<span className="text-red-500 text-sm">{errors.data.weight.message}</span>)}
-                    </div>
-                </CardContent>
-                <CardFooter className="flex justify-between">
-                    <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>
-                        Cancelar
-                    </Button>
-                    <Button type="submit" disabled={isSubmitting}>
-                        {isSubmitting ? 'Guardando...' : 'Guardar'}
-                    </Button>
-                </CardFooter>
-            </form>
+          <CardHeader>
+            <CardTitle>Nuevo Tipo de Evaluación</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <FormField
+              control={form.control}
+              name="data.name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Nombre</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="data.description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Descripción</FormLabel>
+                  <FormControl>
+                    <Textarea {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="data.weight"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Peso</FormLabel>
+                  <FormControl>
+                    <Slider
+                      min={0}
+                      max={1}
+                      step={0.05}
+                      value={[field.value ?? 0]}
+                      onValueChange={(val) => field.onChange(val[0])}
+                    />
+                  </FormControl>
+                  <div className="text-sm text-muted-foreground mt-2">
+                    Valor: {field.value?.toFixed(2)}
+                  </div>
+                  <FormDescription>
+                    Define el peso relativo (0 a 1) de este tipo de evaluación.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </CardContent>
+          <CardFooter className="flex justify-between">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onCancel}
+              disabled={isSubmitting}
+            >
+              Cancelar
+            </Button>
+            <Button
+              type="submit"
+              disabled={isSubmitting || !form.formState.isValid}
+            >
+              {isSubmitting ? 'Guardando...' : 'Guardar'}
+            </Button>
+          </CardFooter>
         </Card>
-    );
+      </form>
+    </Form>
+  );
 };
 

--- a/src/scolar/presentation/ui/GradingSystem/Create/GradingSystemCreateContainer.tsx
+++ b/src/scolar/presentation/ui/GradingSystem/Create/GradingSystemCreateContainer.tsx
@@ -3,8 +3,12 @@ import { useNavigate } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { useTransition } from "react";
 import { toast } from "@/hooks/use-toast";
+import { ToastAction } from "@/components/ui/toast";
 import { GradingSystemCreatePresenter } from "./GradingSystemCreatePresenter";
-import { CreateGradingSystemUseCase, CreateGradingSystemCommand } from "@/scolar/application/useCases/gradingSystems/createGradingSystemUseCase";
+import {
+  CreateGradingSystemUseCase,
+  CreateGradingSystemCommand,
+} from "@/scolar/application/useCases/gradingSystems/createGradingSystemUseCase";
 import { GRADING_SYSTEM_CREATE_USECASE } from "@/scolar/domain/symbols/GradingSystemSymbol";
 
 interface FormValues {
@@ -20,21 +24,38 @@ export const GradingSystemCreateContainer = () => {
     const navigate = useNavigate();
     const [isPending, startTransition] = useTransition();
     const createGS = useInjection<CreateGradingSystemUseCase>(GRADING_SYSTEM_CREATE_USECASE);
-    const { register, handleSubmit, formState: { errors }, watch } = useForm<FormValues>({
+    const form = useForm<FormValues>({
         defaultValues: { data: { name: '', description: '', numberOfTerms: 1, passingScore: '' } }
     });
-    const formData = watch('data');
 
     const onSubmit = (values: FormValues) => {
         startTransition(async () => {
-            const command = new CreateGradingSystemCommand(values.data.name, values.data.description, values.data.numberOfTerms, values.data.passingScore);
+            const command = new CreateGradingSystemCommand(
+                values.data.name,
+                values.data.description,
+                values.data.numberOfTerms,
+                values.data.passingScore
+            );
             const res = await createGS.execute(command);
             if (res.isLeft()) {
                 const fail = res.extract();
                 toast({ title: 'Error', description: fail.map(f => f.getMessage()).join(', '), variant: 'destructive' });
                 return;
             }
-            toast({ title: 'Sistema de calificación creado', description: 'Se creó correctamente', variant: 'success' });
+            const system = res.extract();
+            toast({
+                title: 'Sistema de calificación creado',
+                description: 'Se creó correctamente',
+                variant: 'success',
+                action: (
+                    <ToastAction
+                        altText="Agregar períodos"
+                        onClick={() => navigate(`/terminos-calificacion/nuevo?systemId=${system?.id}`)}
+                    >
+                        Agregar períodos
+                    </ToastAction>
+                ),
+            });
             navigate('/sistemas-calificacion');
         });
     };
@@ -43,12 +64,10 @@ export const GradingSystemCreateContainer = () => {
 
     return (
         <GradingSystemCreatePresenter
-            onSubmit={handleSubmit(onSubmit)}
-            register={register}
-            errors={errors}
+            form={form}
+            onSubmit={onSubmit}
             isSubmitting={isPending}
             onCancel={onCancel}
-            formData={formData}
         />
     );
 };

--- a/src/scolar/presentation/ui/GradingSystem/Create/GradingSystemCreatePresenter.tsx
+++ b/src/scolar/presentation/ui/GradingSystem/Create/GradingSystemCreatePresenter.tsx
@@ -1,9 +1,17 @@
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { FieldErrors, UseFormRegister } from "react-hook-form";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { UseFormReturn } from "react-hook-form";
 
 interface FormValues {
     data: {
@@ -15,49 +23,99 @@ interface FormValues {
 }
 
 interface Props {
-    onSubmit: () => void;
-    onCancel: () => void;
-    register: UseFormRegister<FormValues>;
-    errors: FieldErrors<FormValues>;
-    isSubmitting: boolean;
-    formData: FormValues['data'];
+  form: UseFormReturn<FormValues>;
+  onSubmit: (values: FormValues) => void;
+  onCancel: () => void;
+  isSubmitting: boolean;
 }
 
-export const GradingSystemCreatePresenter = ({ onSubmit, onCancel, register, errors, isSubmitting }: Props) => {
-    return (
+export const GradingSystemCreatePresenter = ({ form, onSubmit, onCancel, isSubmitting }: Props) => {
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
         <Card>
-            <CardHeader>
-                <CardTitle>Nuevo Sistema de Calificación</CardTitle>
-            </CardHeader>
-            <form onSubmit={onSubmit}>
-                <CardContent className="space-y-4">
-                    <div className="space-y-2">
-                        <Label htmlFor="name">Nombre</Label>
-                        <Input id="name" {...register('data.name', { required: true })} />
-                        {errors.data?.name && <span className="text-red-500 text-sm">{errors.data.name.message}</span>}
-                    </div>
-                    <div className="space-y-2">
-                        <Label htmlFor="description">Descripción</Label>
-                        <Textarea id="description" {...register('data.description', { required: true })} />
-                        {errors.data?.description && <span className="text-red-500 text-sm">{errors.data.description.message}</span>}
-                    </div>
-                    <div className="space-y-2">
-                        <Label htmlFor="numberOfTerms">Número de periodos</Label>
-                        <Input id="numberOfTerms" type="number" {...register('data.numberOfTerms', { required: true, valueAsNumber: true })} />
-                        {errors.data?.numberOfTerms && <span className="text-red-500 text-sm">{errors.data.numberOfTerms.message}</span>}
-                    </div>
-                    <div className="space-y-2">
-                        <Label htmlFor="passingScore">Puntaje aprobatorio</Label>
-                        <Input id="passingScore" {...register('data.passingScore', { required: true })} />
-                        {errors.data?.passingScore && <span className="text-red-500 text-sm">{errors.data.passingScore.message}</span>}
-                    </div>
-                </CardContent>
-                <CardFooter className="flex justify-between">
-                    <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>Cancelar</Button>
-                    <Button type="submit" disabled={isSubmitting}>{isSubmitting ? 'Guardando...' : 'Guardar'}</Button>
-                </CardFooter>
-            </form>
+          <CardHeader>
+            <CardTitle>Nuevo Sistema de Calificación</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <FormField
+              control={form.control}
+              name="data.name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Nombre</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="data.description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Descripción</FormLabel>
+                  <FormControl>
+                    <Textarea {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="data.numberOfTerms"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Número de periodos</FormLabel>
+                  <FormControl>
+                    <Input type="number" {...field} />
+                  </FormControl>
+                  <FormDescription>
+                    Cantidad de períodos que tendrá este sistema.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="data.passingScore"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Puntaje aprobatorio</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormDescription>
+                    Calificación mínima requerida para aprobar.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </CardContent>
+          <CardFooter className="flex justify-between">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onCancel}
+              disabled={isSubmitting}
+            >
+              Cancelar
+            </Button>
+            <Button
+              type="submit"
+              disabled={isSubmitting || !form.formState.isValid}
+            >
+              {isSubmitting ? "Guardando..." : "Guardar"}
+            </Button>
+          </CardFooter>
         </Card>
-    );
+      </form>
+    </Form>
+  );
 };
 

--- a/src/scolar/presentation/ui/GradingTerm/Create/GradingTermCreatePresenter.tsx
+++ b/src/scolar/presentation/ui/GradingTerm/Create/GradingTermCreatePresenter.tsx
@@ -12,14 +12,8 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Slider } from "@/components/ui/slider";
+import { SearchSelect } from "@/components/ui/search-select";
 import { useSystems } from "@/scolar/presentation/hooks/useSystems";
 import { useAcademicYears } from "@/scolar/presentation/hooks/useAcademicYears";
 import { GradingSystem } from "@/scolar/domain/entities/grading_system";
@@ -51,6 +45,19 @@ export const GradingTermCreatePresenter = ({
 }: Props) => {
   const systems = useSystems();
   const years = useAcademicYears();
+  const systemOptions = systems.map((s) => ({
+    value: s.id,
+    label: s.name,
+    subLabel: s.description,
+  }));
+  const yearOptions = years.map((y) => ({
+    value: y.id,
+    label: y.name,
+    subLabel: `${format(y.startDate, "dd/MM/yyyy")} - ${format(
+      y.endDate,
+      "dd/MM/yyyy"
+    )}`,
+  }));
   const selectedSystem = systems.find(
     (s: GradingSystem) => s.id === form.watch("data.gradingSystem_id")
   );
@@ -73,30 +80,15 @@ export const GradingTermCreatePresenter = ({
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>Sistema de Calificación</FormLabel>
-                    <Select
-                      onValueChange={(value) => field.onChange(Number(value))}
-                      value={field.value ? String(field.value) : ""}
-                    >
-                      <FormControl>
-                        <SelectTrigger>
-                          <SelectValue placeholder="Seleccione un sistema" />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        {systems.map((s) => (
-                          <SelectItem key={s.id} value={String(s.id)}>
-                            <div className="flex flex-col">
-                              <span>{s.name}</span>
-                              {s.description && (
-                                <span className="text-xs text-muted-foreground">
-                                  {s.description}
-                                </span>
-                              )}
-                            </div>
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <FormControl>
+                      <SearchSelect
+                        options={systemOptions}
+                        value={field.value}
+                        onChange={(v) => field.onChange(Number(v))}
+                        placeholder="Seleccione un sistema"
+                        searchPlaceholder="Buscar sistema..."
+                      />
+                    </FormControl>
                     <FormDescription>
                       Selecciona el sistema al que pertenece el período.
                     </FormDescription>
@@ -116,30 +108,15 @@ export const GradingTermCreatePresenter = ({
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>Año Académico</FormLabel>
-                    <Select
-                      onValueChange={(value) => field.onChange(Number(value))}
-                      value={field.value ? String(field.value) : ""}
-                    >
-                      <FormControl>
-                        <SelectTrigger>
-                          <SelectValue placeholder="Seleccione un año" />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        {years.map((y) => (
-                          <SelectItem key={y.id} value={String(y.id)}>
-                            <div className="flex flex-col">
-                              <span>{y.name}</span>
-                              <span className="text-xs text-muted-foreground">
-                                {format(y.startDate, "dd/MM/yyyy")} -
-                                {" "}
-                                {format(y.endDate, "dd/MM/yyyy")}
-                              </span>
-                            </div>
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <FormControl>
+                      <SearchSelect
+                        options={yearOptions}
+                        value={field.value}
+                        onChange={(v) => field.onChange(Number(v))}
+                        placeholder="Seleccione un año"
+                        searchPlaceholder="Buscar año..."
+                      />
+                    </FormControl>
                     <FormDescription>
                       Selecciona el año académico correspondiente.
                     </FormDescription>


### PR DESCRIPTION
## Summary
- Unify layout for grading system, term and evaluation type forms using shared form components
- Introduce reusable `SearchSelect` combobox for related entities and apply sliders for weights
- Add post-create action linking new grading systems to period creation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: react-refresh/only-export-components and other existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68957ea442cc83308ac97d4e19e82ec0