### PR TITLE
feat: add filter-aware list use cases

### DIFF
--- a/src/scolar/application/useCases/academicPlannings/listAcademicPlanningsByFiltersUseCase.ts
+++ b/src/scolar/application/useCases/academicPlannings/listAcademicPlanningsByFiltersUseCase.ts
@@ -1,0 +1,68 @@
+import { extractErrorMessage } from "@/lib/utils";
+import { PaginateUseCaseCommand, UseCase } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { AcademicPlanning } from "@/scolar/domain/entities/academicPlanning";
+import { AcademicPlanningService } from "@/scolar/domain/services/AcademicPlanningService";
+import { ACADEMIC_PLANNING_SERVICE } from "@/scolar/domain/symbols/AcademicPlanningSymbol";
+import { Left, Right } from "purify-ts/Either";
+import { inject, injectable } from "inversify";
+
+export class ListAcademicPlanningsByFiltersUseCaseCommand extends PaginateUseCaseCommand {
+    constructor(
+        private readonly courseId?: number,
+        private readonly parallelId?: number,
+        private readonly schoolYearId?: number,
+        private readonly subjectId?: number,
+        private readonly topic?: string,
+        page: number = 1,
+        limit: number = 10,
+        orderBy: string[] = [],
+        search?: string,
+    ) {
+        super(page, limit, orderBy, search);
+    }
+
+    get data() {
+        return {
+            ...super.data,
+            course_id: this.courseId,
+            parallel_id: this.parallelId,
+            school_year_id: this.schoolYearId,
+            subject_id: this.subjectId,
+            topic: this.topic,
+        };
+    }
+}
+
+export type ListAcademicPlanningsByFiltersUseCase = UseCase<PaginatedResult<AcademicPlanning>, ListAcademicPlanningsByFiltersUseCaseCommand>;
+
+@injectable()
+export class ListAcademicPlanningsByFiltersUseCaseImpl implements ListAcademicPlanningsByFiltersUseCase {
+    constructor(
+        @inject(ACADEMIC_PLANNING_SERVICE) private readonly service: AcademicPlanningService
+    ) {}
+
+    async execute(command: ListAcademicPlanningsByFiltersUseCaseCommand) {
+        try {
+            const result = await this.service.all(
+                command.data.page,
+                command.data.perPage,
+                command.data.search,
+                command.data.orderBy,
+                {
+                    course_id: command.data.course_id,
+                    parallel_id: command.data.parallel_id,
+                    school_year_id: command.data.school_year_id,
+                    subject_id: command.data.subject_id,
+                    topic: command.data.topic,
+                }
+            );
+            return Right(result);
+        } catch (error) {
+            const _error = extractErrorMessage(error);
+            return Left([_error as Failure]);
+        }
+    }
+}
+

--- a/src/scolar/application/useCases/classSchedules/listClassSchedulesByFiltersUseCase.ts
+++ b/src/scolar/application/useCases/classSchedules/listClassSchedulesByFiltersUseCase.ts
@@ -1,0 +1,68 @@
+import { extractErrorMessage } from "@/lib/utils";
+import { PaginateUseCaseCommand, UseCase } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { ClassSchedule } from "@/scolar/domain/entities/classSchedule";
+import { ClassScheduleService } from "@/scolar/domain/services/ClassScheduleService";
+import { CLASS_SCHEDULE_SERVICE } from "@/scolar/domain/symbols/ClassScheduleSymbol";
+import { Left, Right } from "purify-ts/Either";
+import { inject, injectable } from "inversify";
+
+export class ListClassSchedulesByFiltersUseCaseCommand extends PaginateUseCaseCommand {
+    constructor(
+        private readonly courseId?: number,
+        private readonly parallelId?: number,
+        private readonly schoolYearId?: number,
+        private readonly subjectId?: number,
+        private readonly dayOfWeek?: number,
+        page: number = 1,
+        limit: number = 10,
+        orderBy: string[] = [],
+        search?: string,
+    ) {
+        super(page, limit, orderBy, search);
+    }
+
+    get data() {
+        return {
+            ...super.data,
+            course_id: this.courseId,
+            parallel_id: this.parallelId,
+            school_year_id: this.schoolYearId,
+            subject_id: this.subjectId,
+            day_of_week: this.dayOfWeek,
+        };
+    }
+}
+
+export type ListClassSchedulesByFiltersUseCase = UseCase<PaginatedResult<ClassSchedule>, ListClassSchedulesByFiltersUseCaseCommand>;
+
+@injectable()
+export class ListClassSchedulesByFiltersUseCaseImpl implements ListClassSchedulesByFiltersUseCase {
+    constructor(
+        @inject(CLASS_SCHEDULE_SERVICE) private readonly service: ClassScheduleService
+    ) {}
+
+    async execute(command: ListClassSchedulesByFiltersUseCaseCommand) {
+        try {
+            const result = await this.service.all(
+                command.data.page,
+                command.data.perPage,
+                command.data.search,
+                command.data.orderBy,
+                {
+                    course_id: command.data.course_id,
+                    parallel_id: command.data.parallel_id,
+                    school_year_id: command.data.school_year_id,
+                    subject_id: command.data.subject_id,
+                    day_of_week: command.data.day_of_week,
+                }
+            );
+            return Right(result);
+        } catch (error) {
+            const _error = extractErrorMessage(error);
+            return Left([_error as Failure]);
+        }
+    }
+}
+

--- a/src/scolar/application/useCases/courses/listCoursesByFiltersUseCase.ts
+++ b/src/scolar/application/useCases/courses/listCoursesByFiltersUseCase.ts
@@ -1,0 +1,59 @@
+import { extractErrorMessage } from "@/lib/utils";
+import { PaginateUseCaseCommand, UseCase } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { Course } from "@/scolar/domain/entities/course";
+import { CourseService } from "@/scolar/domain/services/CourseService";
+import { COURSE_SERVICE } from "@/scolar/domain/symbols/CourseSymbol";
+import { Left, Right } from "purify-ts/Either";
+import { inject, injectable } from "inversify";
+
+export class ListCoursesByFiltersUseCaseCommand extends PaginateUseCaseCommand {
+    constructor(
+        private readonly name?: string,
+        private readonly levelId?: number,
+        page: number = 1,
+        limit: number = 10,
+        orderBy: string[] = [],
+        search?: string,
+    ) {
+        super(page, limit, orderBy, search);
+    }
+
+    get data() {
+        return {
+            ...super.data,
+            name: this.name,
+            level_id: this.levelId,
+        };
+    }
+}
+
+export type ListCoursesByFiltersUseCase = UseCase<PaginatedResult<Course>, ListCoursesByFiltersUseCaseCommand>;
+
+@injectable()
+export class ListCoursesByFiltersUseCaseImpl implements ListCoursesByFiltersUseCase {
+    constructor(
+        @inject(COURSE_SERVICE) private readonly service: CourseService
+    ) {}
+
+    async execute(command: ListCoursesByFiltersUseCaseCommand) {
+        try {
+            const result = await this.service.all(
+                command.data.page,
+                command.data.perPage,
+                command.data.search,
+                command.data.orderBy,
+                {
+                    name: command.data.name,
+                    level_id: command.data.level_id,
+                }
+            );
+            return Right(result);
+        } catch (error) {
+            const _error = extractErrorMessage(error);
+            return Left([_error as Failure]);
+        }
+    }
+}
+

--- a/src/scolar/application/useCases/schoolYears/listSchoolYearByFiltersUseCase.ts
+++ b/src/scolar/application/useCases/schoolYears/listSchoolYearByFiltersUseCase.ts
@@ -1,0 +1,59 @@
+import { extractErrorMessage } from "@/lib/utils";
+import { PaginateUseCaseCommand, UseCase } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { SchoolYear } from "@/scolar/domain/entities/school_year";
+import { SchoolYearService } from "@/scolar/domain/services/SchoolYearService";
+import { SCHOOL_YEAR_SERVICE } from "@/scolar/domain/symbols/SchoolYearSymbol";
+import { Left, Right } from "purify-ts/Either";
+import { inject, injectable } from "inversify";
+
+export class ListSchoolYearByFiltersUseCaseCommand extends PaginateUseCaseCommand {
+    constructor(
+        private readonly name?: string,
+        private readonly status?: string,
+        page: number = 1,
+        limit: number = 10,
+        orderBy: string[] = [],
+        search?: string,
+    ) {
+        super(page, limit, orderBy, search);
+    }
+
+    get data() {
+        return {
+            ...super.data,
+            name: this.name,
+            status: this.status,
+        };
+    }
+}
+
+export type ListSchoolYearByFiltersUseCase = UseCase<PaginatedResult<SchoolYear>, ListSchoolYearByFiltersUseCaseCommand>;
+
+@injectable()
+export class ListSchoolYearByFiltersUseCaseImpl implements ListSchoolYearByFiltersUseCase {
+    constructor(
+        @inject(SCHOOL_YEAR_SERVICE) private readonly service: SchoolYearService
+    ) {}
+
+    async execute(command: ListSchoolYearByFiltersUseCaseCommand) {
+        try {
+            const result = await this.service.all(
+                command.data.page,
+                command.data.perPage,
+                command.data.search,
+                command.data.orderBy,
+                {
+                    name: command.data.name,
+                    status: command.data.status,
+                }
+            );
+            return Right(result);
+        } catch (error) {
+            const _error = extractErrorMessage(error);
+            return Left([_error as Failure]);
+        }
+    }
+}
+

--- a/src/scolar/application/useCases/subjects/listSubjectsByFiltersUseCase.ts
+++ b/src/scolar/application/useCases/subjects/listSubjectsByFiltersUseCase.ts
@@ -1,0 +1,59 @@
+import { extractErrorMessage } from "@/lib/utils";
+import { PaginateUseCaseCommand, UseCase } from "@/scolar/application/useCases/useCase";
+import Failure from "@/scolar/domain/failure";
+import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
+import { Subject } from "@/scolar/domain/entities/subject";
+import { SubjectService } from "@/scolar/domain/services/SubjectService";
+import { SUBJECT_SERVICE } from "@/scolar/domain/symbols/SubjectSymbol";
+import { Left, Right } from "purify-ts/Either";
+import { inject, injectable } from "inversify";
+
+export class ListSubjectsByFiltersUseCaseCommand extends PaginateUseCaseCommand {
+    constructor(
+        private readonly name?: string,
+        private readonly code?: string,
+        page: number = 1,
+        limit: number = 10,
+        orderBy: string[] = [],
+        search?: string,
+    ) {
+        super(page, limit, orderBy, search);
+    }
+
+    get data() {
+        return {
+            ...super.data,
+            name: this.name,
+            code: this.code,
+        };
+    }
+}
+
+export type ListSubjectsByFiltersUseCase = UseCase<PaginatedResult<Subject>, ListSubjectsByFiltersUseCaseCommand>;
+
+@injectable()
+export class ListSubjectsByFiltersUseCaseImpl implements ListSubjectsByFiltersUseCase {
+    constructor(
+        @inject(SUBJECT_SERVICE) private readonly service: SubjectService
+    ) {}
+
+    async execute(command: ListSubjectsByFiltersUseCaseCommand) {
+        try {
+            const result = await this.service.all(
+                command.data.page,
+                command.data.perPage,
+                command.data.search,
+                command.data.orderBy,
+                {
+                    name: command.data.name,
+                    code: command.data.code,
+                }
+            );
+            return Right(result);
+        } catch (error) {
+            const _error = extractErrorMessage(error);
+            return Left([_error as Failure]);
+        }
+    }
+}
+

--- a/src/scolar/domain/inversify.ts
+++ b/src/scolar/domain/inversify.ts
@@ -1,4 +1,4 @@
-import { COURSE_CREATE_USECASE, COURSE_DELETE_USECASE, COURSE_GET_USECASE, COURSE_LIST_USECASE, COURSE_REPOSITORY, COURSE_SERVICE, COURSE_UPDATE_USECASE } from "./symbols/CourseSymbol";
+import { COURSE_CREATE_USECASE, COURSE_DELETE_USECASE, COURSE_GET_USECASE, COURSE_LIST_USECASE, COURSE_LIST_BY_FILTERS_USECASE, COURSE_REPOSITORY, COURSE_SERVICE, COURSE_UPDATE_USECASE } from "./symbols/CourseSymbol";
 import { CourseRepositoryImpl } from "../infrastructure/adapters/api/CourseRepositoryImpl";
 import { COURSE_SUBJECT_ASSIGN_TO_COURSE_USECASE, COURSE_SUBJECT_LIST_FROM_COURSE_USECASE, COURSE_SUBJECT_LIST_USECASE, COURSE_SUBJECT_REPOSITORY, COURSE_SUBJECT_SERVICE } from "./symbols/CourseSubjectSymbol";
 import { LEVEL_CREATE_USECASE, LEVEL_DELETE_USECASE, LEVEL_GET_USECASE, LEVEL_LIST_USECASE, LEVEL_REPOSITORY, LEVEL_SERVICE, LEVEL_UPDATE_USECASE } from "./symbols/LevelSymbol";
@@ -6,11 +6,11 @@ import { CourseSubjectRepositoryImpl } from "../infrastructure/adapters/api/Cour
 import { LevelRepositoryImpl } from "../infrastructure/adapters/api/LevelRepositoryImpl";
 import { PARALLEL_CREATE_USECASE, PARALLEL_DELETE_USECASE, PARALLEL_GET_LIST_BY_COURSE_USECASE, PARALLEL_LIST_USECASE, PARALLEL_REPOSITORY, PARALLEL_SERVICE, PARALLEL_UPDATE_USECASE } from "./symbols/ParallelSymbol";
 import { ParallelRepositoryImpl } from "../infrastructure/adapters/api/ParallelRepositoryImpl";
-import { SCHOOL_YEAR_CREATE_USE_CASE, SCHOOL_YEAR_DELETE_USE_CASE, SCHOOL_YEAR_GET_USE_CASE, SCHOOL_YEAR_LIST_USE_CASE, SCHOOL_YEAR_REPOSITORY, SCHOOL_YEAR_SERVICE, SCHOOL_YEAR_UPDATE_USE_CASE } from "./symbols/SchoolYearSymbol";
+import { SCHOOL_YEAR_CREATE_USE_CASE, SCHOOL_YEAR_DELETE_USE_CASE, SCHOOL_YEAR_GET_USE_CASE, SCHOOL_YEAR_LIST_USE_CASE, SCHOOL_YEAR_LIST_BY_FILTERS_USE_CASE, SCHOOL_YEAR_REPOSITORY, SCHOOL_YEAR_SERVICE, SCHOOL_YEAR_UPDATE_USE_CASE } from "./symbols/SchoolYearSymbol";
 import { SchoolYearRepositoryImpl } from "../infrastructure/adapters/api/SchoolYearRepositoryImpl";
 import { SECTION_LIST_USE_CASE, SECTION_REPOSITORY, SECTION_SERVICE } from "./symbols/SectionSymbol";
 import { SectionRepositoryImpl } from "../infrastructure/adapters/api/SectionRepositoryImpl";
-import { SUBJECT_CREATE_USE_CASE, SUBJECT_LIST_USE_CASE, SUBJECT_REPOSITORY, SUBJECT_SERVICE } from "./symbols/SubjectSymbol";
+import { SUBJECT_CREATE_USE_CASE, SUBJECT_LIST_USE_CASE, SUBJECT_LIST_BY_FILTERS_USE_CASE, SUBJECT_REPOSITORY, SUBJECT_SERVICE } from "./symbols/SubjectSymbol";
 import { SubjectRepositoryImpl } from "../infrastructure/adapters/api/SubjectRepositoryImpl";
 import { GRADING_SYSTEM_CREATE_USECASE, GRADING_SYSTEM_DELETE_USECASE, GRADING_SYSTEM_GET_USECASE, GRADING_SYSTEM_LIST_USECASE, GRADING_SYSTEM_REPOSITORY, GRADING_SYSTEM_SERVICE, GRADING_SYSTEM_UPDATE_USECASE } from "./symbols/GradingSystemSymbol";
 import { GradingSystemRepositoryImpl } from "../infrastructure/adapters/api/GradingSystemRepositoryImpl";
@@ -44,7 +44,9 @@ import { CreateLevelUseCaseImpl } from "../application/useCases/levels/createLev
 import { CourseService } from "./services/CourseService";
 import { SubjectService } from "./services/SubjectService";
 import { ListSubjectUseCaseImpl } from "../application/useCases/subjects/listSubjectsUseCase";
+import { ListSubjectsByFiltersUseCaseImpl } from "../application/useCases/subjects/listSubjectsByFiltersUseCase";
 import { ListCoursesUseCaseImpl } from "../application/useCases/courses/listCoursesUseCase";
+import { ListCoursesByFiltersUseCaseImpl } from "../application/useCases/courses/listCoursesByFiltersUseCase";
 import { CreateCourseUseCaseImpl } from "../application/useCases/courses/createCourseUseCase";
 import { DeleteCourseUseCaseImpl } from "../application/useCases/courses/deleteCourseUseCase";
 import { UpdateCourseUseCaseImpl } from "../application/useCases/courses/updateCourseUseCase";
@@ -55,6 +57,7 @@ import { CourseSubjetService } from "./services/CourseSubjectService";
 import { ListSubjectFromCourseUseCaseImpl } from "../application/useCases/courses/listSubjectFromCourse";
 import { SchoolYearService } from "./services/SchoolYearService";
 import { ListSchoolYearUseCaseImpl } from "../application/useCases/schoolYears/listSchoolYearUseCase";
+import { ListSchoolYearByFiltersUseCaseImpl } from "../application/useCases/schoolYears/listSchoolYearByFiltersUseCase";
 import { ListParallelUseCaseImpl } from "../application/useCases/parallels/listParallelUseCase";
 import { CreateSchoolYearUseCaseImpl } from "../application/useCases/schoolYears/createSchoolYearUseCase";
 import { UpdateSchoolYearUseCaseImpl } from "../application/useCases/schoolYears/updateSchoolYearUseCase";
@@ -95,18 +98,20 @@ import { ListBehaviorScalesUseCaseImpl } from "../application/useCases/behaviorS
 import { CreateBehaviorScaleUseCaseImpl } from "../application/useCases/behaviorScales/createBehaviorScaleUseCase";
 import { UpdateBehaviorScaleUseCaseImpl } from "../application/useCases/behaviorScales/updateBehaviorScaleUseCase";
 import { DeleteBehaviorScaleUseCaseImpl } from "../application/useCases/behaviorScales/deleteBehaviorScaleUseCase";
-import { CLASS_SCHEDULE_REPOSITORY, CLASS_SCHEDULE_SERVICE, CLASS_SCHEDULE_LIST_USE_CASE, CLASS_SCHEDULE_CREATE_USE_CASE, CLASS_SCHEDULE_UPDATE_USE_CASE, CLASS_SCHEDULE_DELETE_USE_CASE, CLASS_SCHEDULE_GET_USE_CASE } from "./symbols/ClassScheduleSymbol";
+import { CLASS_SCHEDULE_REPOSITORY, CLASS_SCHEDULE_SERVICE, CLASS_SCHEDULE_LIST_USE_CASE, CLASS_SCHEDULE_LIST_BY_FILTERS_USE_CASE, CLASS_SCHEDULE_CREATE_USE_CASE, CLASS_SCHEDULE_UPDATE_USE_CASE, CLASS_SCHEDULE_DELETE_USE_CASE, CLASS_SCHEDULE_GET_USE_CASE } from "./symbols/ClassScheduleSymbol";
 import { ClassScheduleRepositoryImpl } from "../infrastructure/adapters/api/ClassScheduleRepositoryImpl";
 import { ClassScheduleService } from "./services/ClassScheduleService";
 import { ListClassSchedulesUseCaseImpl } from "../application/useCases/classSchedules/listClassSchedulesUseCase";
+import { ListClassSchedulesByFiltersUseCaseImpl } from "../application/useCases/classSchedules/listClassSchedulesByFiltersUseCase";
 import { CreateClassScheduleUseCaseImpl } from "../application/useCases/classSchedules/createClassScheduleUseCase";
 import { UpdateClassScheduleUseCaseImpl } from "../application/useCases/classSchedules/updateClassScheduleUseCase";
 import { DeleteClassScheduleUseCaseImpl } from "../application/useCases/classSchedules/deleteClassScheduleUseCase";
 import { GetClassScheduleUseCaseImpl } from "../application/useCases/classSchedules/getClassScheduleUseCase";
-import { ACADEMIC_PLANNING_REPOSITORY, ACADEMIC_PLANNING_SERVICE, ACADEMIC_PLANNING_LIST_USE_CASE, ACADEMIC_PLANNING_CREATE_USE_CASE, ACADEMIC_PLANNING_UPDATE_USE_CASE, ACADEMIC_PLANNING_DELETE_USE_CASE, ACADEMIC_PLANNING_GET_USE_CASE } from "./symbols/AcademicPlanningSymbol";
+import { ACADEMIC_PLANNING_REPOSITORY, ACADEMIC_PLANNING_SERVICE, ACADEMIC_PLANNING_LIST_USE_CASE, ACADEMIC_PLANNING_LIST_BY_FILTERS_USE_CASE, ACADEMIC_PLANNING_CREATE_USE_CASE, ACADEMIC_PLANNING_UPDATE_USE_CASE, ACADEMIC_PLANNING_DELETE_USE_CASE, ACADEMIC_PLANNING_GET_USE_CASE } from "./symbols/AcademicPlanningSymbol";
 import { AcademicPlanningRepositoryImpl } from "../infrastructure/adapters/api/AcademicPlanningRepositoryImpl";
 import { AcademicPlanningService } from "./services/AcademicPlanningService";
 import { ListAcademicPlanningsUseCaseImpl } from "../application/useCases/academicPlannings/listAcademicPlanningsUseCase";
+import { ListAcademicPlanningsByFiltersUseCaseImpl } from "../application/useCases/academicPlannings/listAcademicPlanningsByFiltersUseCase";
 import { CreateAcademicPlanningUseCaseImpl } from "../application/useCases/academicPlannings/createAcademicPlanningUseCase";
 import { UpdateAcademicPlanningUseCaseImpl } from "../application/useCases/academicPlannings/updateAcademicPlanningUseCase";
 import { DeleteAcademicPlanningUseCaseImpl } from "../application/useCases/academicPlannings/deleteAcademicPlanningUseCase";
@@ -185,9 +190,11 @@ const contianerScolar = new ContainerModule(
 
         bind(COURSE_SERVICE).to(CourseService);
         bind(COURSE_LIST_USECASE).to(ListCoursesUseCaseImpl);
+        bind(COURSE_LIST_BY_FILTERS_USECASE).to(ListCoursesByFiltersUseCaseImpl);
 
         bind(SUBJECT_SERVICE).to(SubjectService);
         bind(SUBJECT_LIST_USE_CASE).to(ListSubjectUseCaseImpl)
+        bind(SUBJECT_LIST_BY_FILTERS_USE_CASE).to(ListSubjectsByFiltersUseCaseImpl)
         bind(SUBJECT_CREATE_USE_CASE).to(CreateSubjectUseCaseImpl)
 
         bind(COURSE_CREATE_USECASE).to(CreateCourseUseCaseImpl);
@@ -199,6 +206,7 @@ const contianerScolar = new ContainerModule(
         bind(COURSE_SUBJECT_LIST_USECASE).to(ListSubjectFromCourseUseCaseImpl)
         bind(SCHOOL_YEAR_SERVICE).to(SchoolYearService)
         bind(SCHOOL_YEAR_LIST_USE_CASE).to(ListSchoolYearUseCaseImpl)
+        bind(SCHOOL_YEAR_LIST_BY_FILTERS_USE_CASE).to(ListSchoolYearByFiltersUseCaseImpl)
         bind(SCHOOL_YEAR_CREATE_USE_CASE).to(CreateSchoolYearUseCaseImpl)
         bind(SCHOOL_YEAR_UPDATE_USE_CASE).to(UpdateSchoolYearUseCaseImpl)
         bind(SCHOOL_YEAR_GET_USE_CASE).to(GetSchoolYearUseCaseImpl);
@@ -246,6 +254,7 @@ const contianerScolar = new ContainerModule(
         })
         bind(CLASS_SCHEDULE_SERVICE).to(ClassScheduleService)
         bind(CLASS_SCHEDULE_LIST_USE_CASE).to(ListClassSchedulesUseCaseImpl)
+        bind(CLASS_SCHEDULE_LIST_BY_FILTERS_USE_CASE).to(ListClassSchedulesByFiltersUseCaseImpl)
         bind(CLASS_SCHEDULE_CREATE_USE_CASE).to(CreateClassScheduleUseCaseImpl)
         bind(CLASS_SCHEDULE_UPDATE_USE_CASE).to(UpdateClassScheduleUseCaseImpl)
         bind(CLASS_SCHEDULE_DELETE_USE_CASE).to(DeleteClassScheduleUseCaseImpl)
@@ -256,6 +265,7 @@ const contianerScolar = new ContainerModule(
         })
         bind(ACADEMIC_PLANNING_SERVICE).to(AcademicPlanningService)
         bind(ACADEMIC_PLANNING_LIST_USE_CASE).to(ListAcademicPlanningsUseCaseImpl)
+        bind(ACADEMIC_PLANNING_LIST_BY_FILTERS_USE_CASE).to(ListAcademicPlanningsByFiltersUseCaseImpl)
         bind(ACADEMIC_PLANNING_CREATE_USE_CASE).to(CreateAcademicPlanningUseCaseImpl)
         bind(ACADEMIC_PLANNING_UPDATE_USE_CASE).to(UpdateAcademicPlanningUseCaseImpl)
         bind(ACADEMIC_PLANNING_DELETE_USE_CASE).to(DeleteAcademicPlanningUseCaseImpl)

--- a/src/scolar/domain/repositories/AcademicPlanningRepository.ts
+++ b/src/scolar/domain/repositories/AcademicPlanningRepository.ts
@@ -2,7 +2,19 @@ import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
 import { AcademicPlanningDto } from "../../infrastructure/dto/AcademicPlanningDto";
 
 export interface AcademicPlanningRepository {
-    findAll(page: number, limit: number, search?: string, orderby?: string[]): Promise<PaginatedResult<AcademicPlanningDto>>;
+    findAll(
+        page: number,
+        limit: number,
+        search?: string,
+        orderby?: string[],
+        filters?: {
+            course_id?: number;
+            parallel_id?: number;
+            school_year_id?: number;
+            subject_id?: number;
+            topic?: string;
+        },
+    ): Promise<PaginatedResult<AcademicPlanningDto>>;
     findById(id: number): Promise<AcademicPlanningDto>;
     create(data: Omit<AcademicPlanningDto, 'id'>): Promise<AcademicPlanningDto>;
     update(id: number, data: Omit<AcademicPlanningDto, 'id'>): Promise<AcademicPlanningDto>;

--- a/src/scolar/domain/repositories/ClassScheduleRepository.ts
+++ b/src/scolar/domain/repositories/ClassScheduleRepository.ts
@@ -2,7 +2,19 @@ import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
 import { ClassScheduleDto } from "../../infrastructure/dto/ClassScheduleDto";
 
 export interface ClassScheduleRepository {
-    findAll(page: number, limit: number, search?: string, orderby?: string[]): Promise<PaginatedResult<ClassScheduleDto>>;
+    findAll(
+        page: number,
+        limit: number,
+        search?: string,
+        orderby?: string[],
+        filters?: {
+            course_id?: number;
+            parallel_id?: number;
+            school_year_id?: number;
+            subject_id?: number;
+            day_of_week?: number;
+        },
+    ): Promise<PaginatedResult<ClassScheduleDto>>;
     findById(id: number): Promise<ClassScheduleDto>;
     create(data: Omit<ClassScheduleDto, 'id'>): Promise<ClassScheduleDto>;
     update(id: number, data: Omit<ClassScheduleDto, 'id'>): Promise<ClassScheduleDto>;

--- a/src/scolar/domain/repositories/CourseRepository.ts
+++ b/src/scolar/domain/repositories/CourseRepository.ts
@@ -4,8 +4,16 @@ import { CourseDto } from "../../infrastructure/dto/CourseDto";
 
 export interface CourseRepository {
 
-    findAll(page: number, limit: number, search?: string, orderby?: string[])
-    : Promise<PaginatedResult<CourseDto>>;
+    findAll(
+        page: number,
+        limit: number,
+        search?: string,
+        orderby?: string[],
+        filters?: {
+            name?: string;
+            level_id?: number;
+        },
+    ): Promise<PaginatedResult<CourseDto>>;
 
     create(course: Omit<CourseDto, 'id'| 'level'>): Promise<CourseDto>;
 

--- a/src/scolar/domain/repositories/SchoolYearRepository.ts
+++ b/src/scolar/domain/repositories/SchoolYearRepository.ts
@@ -7,7 +7,11 @@ export interface SchoolYearRepository {
         page: number,
         limit: number,
         search?: string,
-        orderby?: string[]
+        orderby?: string[],
+        filters?: {
+            name?: string;
+            status?: string;
+        },
     ): Promise<PaginatedResult<SchoolYearDto>>;
     findById(id: number): Promise<SchoolYearDto>;
 

--- a/src/scolar/domain/repositories/SubjectRepository.ts
+++ b/src/scolar/domain/repositories/SubjectRepository.ts
@@ -2,8 +2,16 @@ import { PaginatedResult } from "@/scolar/infrastructure/dto/paginateDto";
 import { SubjectDto } from "../../infrastructure/dto/SubjectDto";
 
 export interface SubjectRepository {
-    findAll(page: number, limit: number, search?: string, orderby?: string[]):
-        Promise<PaginatedResult<SubjectDto>>;
+    findAll(
+        page: number,
+        limit: number,
+        search?: string,
+        orderby?: string[],
+        filters?: {
+            name?: string;
+            code?: string;
+        },
+    ): Promise<PaginatedResult<SubjectDto>>;
     findById(id: number): Promise<SubjectDto>;
     create(subject: Omit<SubjectDto, 'id'>): Promise<SubjectDto>;
     update(id: number, subject: Omit<SubjectDto, 'id'>): Promise<SubjectDto>;

--- a/src/scolar/domain/services/AcademicPlanningService.ts
+++ b/src/scolar/domain/services/AcademicPlanningService.ts
@@ -12,8 +12,20 @@ export class AcademicPlanningService {
         private repository: AcademicPlanningRepository
     ) {}
 
-    async all(page: number, size: number, search?: string, order?: string[]) {
-        const res = await this.repository.findAll(page, size, search, order);
+    async all(
+        page: number,
+        size: number,
+        search?: string,
+        order?: string[],
+        filters?: {
+            course_id?: number;
+            parallel_id?: number;
+            school_year_id?: number;
+            subject_id?: number;
+            topic?: string;
+        },
+    ) {
+        const res = await this.repository.findAll(page, size, search, order, filters);
         return {
             ...res,
             data: res.data.map(AcademicPlanningMapper.toDomain),

--- a/src/scolar/domain/services/ClassScheduleService.ts
+++ b/src/scolar/domain/services/ClassScheduleService.ts
@@ -12,8 +12,20 @@ export class ClassScheduleService {
         private repository: ClassScheduleRepository
     ) {}
 
-    async all(page: number, size: number, search?: string, order?: string[]) {
-        const res = await this.repository.findAll(page, size, search, order);
+    async all(
+        page: number,
+        size: number,
+        search?: string,
+        order?: string[],
+        filters?: {
+            course_id?: number;
+            parallel_id?: number;
+            school_year_id?: number;
+            subject_id?: number;
+            day_of_week?: number;
+        },
+    ) {
+        const res = await this.repository.findAll(page, size, search, order, filters);
         return {
             ...res,
             data: res.data.map(ClassScheduleMapper.toDomain),

--- a/src/scolar/domain/services/CourseService.ts
+++ b/src/scolar/domain/services/CourseService.ts
@@ -13,8 +13,14 @@ export class CourseService{
          private repository: CourseRepository
     ){}
 
-    async all(page: number, size: number, search?: string, order?: string[]){
-        const res = await this.repository.findAll(page, size, search, order);
+    async all(
+        page: number,
+        size: number,
+        search?: string,
+        order?: string[],
+        filters?: { name?: string; level_id?: number }
+    ){
+        const res = await this.repository.findAll(page, size, search, order, filters);
         return {
             ...res,
             data: res.data.map(CourseMapper.toDomain)

--- a/src/scolar/domain/services/SchoolYearService.ts
+++ b/src/scolar/domain/services/SchoolYearService.ts
@@ -15,8 +15,14 @@ export class SchoolYearService {
     ){}
 
 
-    async all(page: number, size: number, search?: string, order?: string[]) {
-        const res = await this.repository.findAll(page, size, search, order);
+    async all(
+        page: number,
+        size: number,
+        search?: string,
+        order?: string[],
+        filters?: { name?: string; status?: string }
+    ) {
+        const res = await this.repository.findAll(page, size, search, order, filters);
         return {
             ...res,
             data: res.data.map(SchoolYearMapper.toDomain),

--- a/src/scolar/domain/services/SubjectService.ts
+++ b/src/scolar/domain/services/SubjectService.ts
@@ -13,8 +13,14 @@ export class SubjectService{
          private repository: SubjectRepository
     ){}
 
-    async all(page: number, size: number, search?: string, order?: string[]){
-        const res = await this.repository.findAll(page, size, search, order);
+    async all(
+        page: number,
+        size: number,
+        search?: string,
+        order?: string[],
+        filters?: { name?: string; code?: string }
+    ){
+        const res = await this.repository.findAll(page, size, search, order, filters);
         return {
             ...res,
             data: res.data.map(SubjectMapper.toDomain)

--- a/src/scolar/domain/symbols/AcademicPlanningSymbol.ts
+++ b/src/scolar/domain/symbols/AcademicPlanningSymbol.ts
@@ -1,6 +1,7 @@
 export const ACADEMIC_PLANNING_REPOSITORY = Symbol('AcademicPlanningRepository');
 export const ACADEMIC_PLANNING_SERVICE = Symbol('AcademicPlanningService');
 export const ACADEMIC_PLANNING_LIST_USE_CASE = Symbol('ListAcademicPlanningUseCase');
+export const ACADEMIC_PLANNING_LIST_BY_FILTERS_USE_CASE = Symbol('ListAcademicPlanningByFiltersUseCase');
 export const ACADEMIC_PLANNING_CREATE_USE_CASE = Symbol('CreateAcademicPlanningUseCase');
 export const ACADEMIC_PLANNING_UPDATE_USE_CASE = Symbol('UpdateAcademicPlanningUseCase');
 export const ACADEMIC_PLANNING_DELETE_USE_CASE = Symbol('DeleteAcademicPlanningUseCase');

--- a/src/scolar/domain/symbols/ClassScheduleSymbol.ts
+++ b/src/scolar/domain/symbols/ClassScheduleSymbol.ts
@@ -1,6 +1,7 @@
 export const CLASS_SCHEDULE_REPOSITORY = Symbol('ClassScheduleRepository');
 export const CLASS_SCHEDULE_SERVICE = Symbol('ClassScheduleService');
 export const CLASS_SCHEDULE_LIST_USE_CASE = Symbol('ListClassScheduleUseCase');
+export const CLASS_SCHEDULE_LIST_BY_FILTERS_USE_CASE = Symbol('ListClassScheduleByFiltersUseCase');
 export const CLASS_SCHEDULE_CREATE_USE_CASE = Symbol('CreateClassScheduleUseCase');
 export const CLASS_SCHEDULE_UPDATE_USE_CASE = Symbol('UpdateClassScheduleUseCase');
 export const CLASS_SCHEDULE_DELETE_USE_CASE = Symbol('DeleteClassScheduleUseCase');

--- a/src/scolar/domain/symbols/CourseSymbol.ts
+++ b/src/scolar/domain/symbols/CourseSymbol.ts
@@ -5,6 +5,7 @@ export const COURSE_REPOSITORY = Symbol('CourseRepository');
 export const COURSE_SERVICE = Symbol('CourseService');
 export const COURSE_CREATE_USECASE = Symbol('CourseCreateUseCase');
 export const COURSE_LIST_USECASE = Symbol('CourseListUseCase');
+export const COURSE_LIST_BY_FILTERS_USECASE = Symbol('CourseListByFiltersUseCase');
 export const COURSE_UPDATE_USECASE = Symbol('CourseUpdateUseCase');
 export const COURSE_DELETE_USECASE = Symbol('CourseDeleteUseCase');
 export const COURSE_GET_USECASE = Symbol('CourseGetUseCase');

--- a/src/scolar/domain/symbols/SchoolYearSymbol.ts
+++ b/src/scolar/domain/symbols/SchoolYearSymbol.ts
@@ -8,5 +8,6 @@ export const SCHOOL_YEAR_CREATE_USE_CASE = Symbol('SchoolYearCreateUseCase');
 export const SCHOOL_YEAR_UPDATE_USE_CASE = Symbol('SchoolYearUpdateUseCase');
 export const SCHOOL_YEAR_DELETE_USE_CASE = Symbol('SchoolYearDeleteUseCase');
 export const SCHOOL_YEAR_LIST_USE_CASE = Symbol('SchoolYearListUseCase');
+export const SCHOOL_YEAR_LIST_BY_FILTERS_USE_CASE = Symbol('SchoolYearListByFiltersUseCase');
 
 export const SCHOOL_YEAR_GET_USE_CASE = Symbol('SchoolYearGetUseCase');

--- a/src/scolar/domain/symbols/SubjectSymbol.ts
+++ b/src/scolar/domain/symbols/SubjectSymbol.ts
@@ -3,6 +3,7 @@ export const SUBJECT_REPOSITORY = Symbol('SubjectRepository');
 export const SUBJECT_SERVICE = Symbol('SubjectService');
 
 export const SUBJECT_LIST_USE_CASE = Symbol('ListSubjectUseCase');
+export const SUBJECT_LIST_BY_FILTERS_USE_CASE = Symbol('ListSubjectByFiltersUseCase');
 export const SUBJECT_CREATE_USE_CASE = Symbol('CreateSubjectUseCase');
 export const SUBJECT_UPDATE_USE_CASE = Symbol('UpdateSubjectUseCase');
 export const SUBJECT_DELETE_USE_CASE = Symbol('DeleteSubjectUseCase');

--- a/src/scolar/infrastructure/adapters/api/AcademicPlanningRepositoryImpl.ts
+++ b/src/scolar/infrastructure/adapters/api/AcademicPlanningRepositoryImpl.ts
@@ -8,9 +8,21 @@ import { AcademicPlanningRepository } from "@/scolar/domain/repositories/Academi
 export class AcademicPlanningRepositoryImpl implements AcademicPlanningRepository {
     constructor(private readonly http: AxiosInstance) {}
 
-    async findAll(page: number, limit: number, search?: string, orderby?: string[]): Promise<PaginatedResult<AcademicPlanningDto>> {
+    async findAll(
+        page: number,
+        limit: number,
+        search?: string,
+        orderby?: string[],
+        filters?: {
+            course_id?: number;
+            parallel_id?: number;
+            school_year_id?: number;
+            subject_id?: number;
+            topic?: string;
+        },
+    ): Promise<PaginatedResult<AcademicPlanningDto>> {
         const { data } = await this.http.get<PaginatedResult<AcademicPlanningDto>>("/academic-plannings/", {
-            params: { page, limit, search, orderby },
+            params: { page, limit, search, orderby, ...(filters ?? {}) },
         });
         return data;
     }
@@ -18,11 +30,11 @@ export class AcademicPlanningRepositoryImpl implements AcademicPlanningRepositor
         const { data } = await this.http.get<AcademicPlanningDto>(`/academic-plannings/${id}`);
         return data;
     }
-    async create(entity: Omit<AcademicPlanningDto, 'id'>): Promise<AcademicPlanningDto> {
+    async create(entity: Omit<AcademicPlanningDto, "id">): Promise<AcademicPlanningDto> {
         const { data } = await this.http.post<AcademicPlanningDto>("/academic-plannings/", entity);
         return data;
     }
-    async update(id: number, entity: Omit<AcademicPlanningDto, 'id'>): Promise<AcademicPlanningDto> {
+    async update(id: number, entity: Omit<AcademicPlanningDto, "id">): Promise<AcademicPlanningDto> {
         const { data } = await this.http.put<AcademicPlanningDto>(`/academic-plannings/${id}`, entity);
         return data;
     }
@@ -30,3 +42,4 @@ export class AcademicPlanningRepositoryImpl implements AcademicPlanningRepositor
         await this.http.delete(`/academic-plannings/${id}`);
     }
 }
+

--- a/src/scolar/infrastructure/adapters/api/ClassScheduleRepositoryImpl.ts
+++ b/src/scolar/infrastructure/adapters/api/ClassScheduleRepositoryImpl.ts
@@ -8,9 +8,21 @@ import { ClassScheduleRepository } from "@/scolar/domain/repositories/ClassSched
 export class ClassScheduleRepositoryImpl implements ClassScheduleRepository {
     constructor(private readonly http: AxiosInstance) {}
 
-    async findAll(page: number, limit: number, search?: string, orderby?: string[]): Promise<PaginatedResult<ClassScheduleDto>> {
+    async findAll(
+        page: number,
+        limit: number,
+        search?: string,
+        orderby?: string[],
+        filters?: {
+            course_id?: number;
+            parallel_id?: number;
+            school_year_id?: number;
+            subject_id?: number;
+            day_of_week?: number;
+        },
+    ): Promise<PaginatedResult<ClassScheduleDto>> {
         const { data } = await this.http.get<PaginatedResult<ClassScheduleDto>>("/class-schedules/", {
-            params: { page, limit, search, orderby },
+            params: { page, limit, search, orderby, ...(filters ?? {}) },
         });
         return data;
     }
@@ -18,11 +30,11 @@ export class ClassScheduleRepositoryImpl implements ClassScheduleRepository {
         const { data } = await this.http.get<ClassScheduleDto>(`/class-schedules/${id}/`);
         return data;
     }
-    async create(entity: Omit<ClassScheduleDto, 'id'>): Promise<ClassScheduleDto> {
+    async create(entity: Omit<ClassScheduleDto, "id">): Promise<ClassScheduleDto> {
         const { data } = await this.http.post<ClassScheduleDto>("/class-schedules/", entity);
         return data;
     }
-    async update(id: number, entity: Omit<ClassScheduleDto, 'id'>): Promise<ClassScheduleDto> {
+    async update(id: number, entity: Omit<ClassScheduleDto, "id">): Promise<ClassScheduleDto> {
         const { data } = await this.http.put<ClassScheduleDto>(`/class-schedules/${id}/`, entity);
         return data;
     }
@@ -30,3 +42,4 @@ export class ClassScheduleRepositoryImpl implements ClassScheduleRepository {
         await this.http.delete(`/class-schedules/${id}/`);
     }
 }
+

--- a/src/scolar/infrastructure/adapters/api/CourseRepositoryImpl.ts
+++ b/src/scolar/infrastructure/adapters/api/CourseRepositoryImpl.ts
@@ -8,13 +8,20 @@ import { injectable } from "inversify";
 export class CourseRepositoryImpl implements CourseRepository{
 
     constructor(private readonly http: AxiosInstance) {}
-    async findAll(page: number, limit: number, search?: string, orderby?: string[]): Promise<PaginatedResult<CourseDto>> {
+    async findAll(
+        page: number,
+        limit: number,
+        search?: string,
+        orderby?: string[],
+        filters?: { name?: string; level_id?: number }
+    ): Promise<PaginatedResult<CourseDto>> {
         const { data } = await this.http.get<PaginatedResult<CourseDto>>("/courses/", {
             params: {
                 page,
                 limit,
                 search,
-                orderby
+                orderby,
+                ...(filters ?? {})
             }
         });
         return data;

--- a/src/scolar/infrastructure/adapters/api/SchoolYearRepositoryImpl.ts
+++ b/src/scolar/infrastructure/adapters/api/SchoolYearRepositoryImpl.ts
@@ -11,13 +11,20 @@ export class SchoolYearRepositoryImpl implements SchoolYearRepository{
         const { data } = await this.http.get<SchoolYearDto>(`/school-years/${id}/`);
         return data;
     }
-    async findAll(page: number, limit: number, search?: string, orderby?: string[]): Promise<PaginatedResult<SchoolYearDto>> {
+    async findAll(
+        page: number,
+        limit: number,
+        search?: string,
+        orderby?: string[],
+        filters?: { name?: string; status?: string }
+    ): Promise<PaginatedResult<SchoolYearDto>> {
         const { data } = await this.http.get<PaginatedResult<SchoolYearDto>>("/school-years/", {
             params: {
                 page,
                 limit,
                 search,
-                orderby
+                orderby,
+                ...(filters ?? {})
             }
         });
         return data;

--- a/src/scolar/infrastructure/adapters/api/SubjectRepositoryImpl.ts
+++ b/src/scolar/infrastructure/adapters/api/SubjectRepositoryImpl.ts
@@ -9,13 +9,20 @@ import { injectable } from "inversify";
 export class SubjectRepositoryImpl implements SubjectRepository{
 
     constructor(private readonly http: AxiosInstance) {}
-    async findAll(page: number, limit: number, search?: string, orderby?: string[]): Promise<PaginatedResult<SubjectDto>> {
+    async findAll(
+        page: number,
+        limit: number,
+        search?: string,
+        orderby?: string[],
+        filters?: { name?: string; code?: string }
+    ): Promise<PaginatedResult<SubjectDto>> {
         const { data } = await this.http.get<PaginatedResult<SubjectDto>>("/subjects/", {
             params: {
                 page,
                 limit,
                 search,
-                orderby
+                orderby,
+                ...(filters ?? {})
             }
         });
 


### PR DESCRIPTION
## Summary
- add filtered list use cases for courses, subjects, school years, class schedules, and academic plannings
- extend repositories and services to forward optional filter params
- register new use cases in DI container

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 31 problems; 11 errors)


------
https://chatgpt.com/codex/tasks/task_e_689d3b4ebeec8330a428fdded1d1e60f